### PR TITLE
Fix extracting phrase center RA and Dec from the UVFITS header.

### DIFF
--- a/fhd_core/vis_header_extract.pro
+++ b/fhd_core/vis_header_extract.pro
@@ -53,8 +53,8 @@ ENDIF ELSE BEGIN
   wh_dec = where(param_names eq 'dec', count_dec)
   if count_dec eq 1 then dec_cnum = wh_dec+1 else message, 'DEC CTYPE not found'
  
-  obsra=sxpar(header,'CRVAL' + strn(ra_cnum))
-  obsdec=sxpar(header,'CRVAL' + strn(dec_cnum))  
+  obsra=sxpar(header,'CRVAL' + strn(ra_cnum[0]))
+  obsdec=sxpar(header,'CRVAL' + strn(dec_cnum[0]))  
 ENDELSE
 
 baseline_i=(where(Strmatch(param_list,'BASELINE'),found_baseline))[0]


### PR DESCRIPTION
Lines 56 and 57 in vis_header_extract.pro should be:

```
obsra=sxpar(header,'CRVAL' + strn(ra_cnum[0]))
obsdec=sxpar(header,'CRVAL' + strn(dec_cnum[0]))
```

ra_cnum and dec_cnum are arrays of length 1, making the concatenated string
arrays too. sxpar will report no keyword found and always return 0. This
makes PHRASERA, PHRASEDEC, OBSRA, OBSDEC, ORIG_PHRASERA and ORIG_PHRASEDEC
all zero, resulting in incorrect pointing, and thus the cause of the oblige
SIN projection. The EoR run from last year was not affected by this bug
because of the use of the meta FITS.
