### PR TITLE
Bug fix: extended sources were erased from skymodel during calibration

### DIFF
--- a/fhd_core/calibration/vis_calibrate.pro
+++ b/fhd_core/calibration/vis_calibrate.pro
@@ -158,7 +158,9 @@ IF N_Elements(calibration_flag_iterate) EQ 0 THEN calibration_flag_iterate=0
 ;    IF Keyword_Set(flag_calibration) THEN calibration_flag_iterate=1 ELSE calibration_flag_iterate=0
 
 t2=0
-cal_base=cal & FOR pol_i=0,nc_pol-1 DO cal_base.gain[pol_i]=Ptr_new(*cal.gain[pol_i])
+cal_base=cal
+cal_base.gain = Pointer_copy(cal.gain)
+cal_base.skymodel = Pointer_copy(cal.skymodel)
 FOR iter=0,calibration_flag_iterate DO BEGIN
     t2_a=Systime(1)
     IF iter LT calibration_flag_iterate THEN preserve_flag=1 ELSE preserve_flag=preserve_visibilities
@@ -172,7 +174,9 @@ FOR iter=0,calibration_flag_iterate DO BEGIN
 
 ENDFOR
 undefine_fhd,cal_base
-cal_base=cal & FOR pol_i=0,nc_pol-1 DO cal_base.gain[pol_i]=Ptr_new(*cal.gain[pol_i])
+cal_base=cal
+cal_base.gain = Pointer_copy(cal.gain)
+cal_base.skymodel = Pointer_copy(cal.skymodel)
 
 IF Keyword_Set(bandpass_calibrate) THEN BEGIN
     cal_bandpass=vis_cal_bandpass(cal,obs,cal_remainder=cal_remainder,file_path_fhd=file_path_fhd,_Extra=extra)
@@ -202,7 +206,7 @@ plot_cals,cal,obs,cal_res=cal_res,cal_auto=cal_auto,file_path_base=image_path,_E
 IF Keyword_Set(calibration_auto_fit) THEN cal=cal_auto
 vis_cal=vis_calibration_apply(vis_ptr,cal)
 cal.gain_residual=cal_res.gain
-;undefine_fhd,cal_base
+undefine_fhd,cal_base
 
 IF Keyword_Set(vis_baseline_hist) THEN $
     vis_baseline_hist,obs,params,vis_arr=vis_cal,vis_model_arr=vis_model_arr,file_path_fhd=file_path_fhd

--- a/fhd_core/calibration/vis_calibrate.pro
+++ b/fhd_core/calibration/vis_calibrate.pro
@@ -158,9 +158,6 @@ IF N_Elements(calibration_flag_iterate) EQ 0 THEN calibration_flag_iterate=0
 ;    IF Keyword_Set(flag_calibration) THEN calibration_flag_iterate=1 ELSE calibration_flag_iterate=0
 
 t2=0
-cal_base=cal
-cal_base.gain = Pointer_copy(cal.gain)
-cal_base.skymodel = Pointer_copy(cal.skymodel)
 FOR iter=0,calibration_flag_iterate DO BEGIN
     t2_a=Systime(1)
     IF iter LT calibration_flag_iterate THEN preserve_flag=1 ELSE preserve_flag=preserve_visibilities
@@ -173,10 +170,7 @@ FOR iter=0,calibration_flag_iterate DO BEGIN
     IF Keyword_Set(n_tile_cut) THEN BREAK
 
 ENDFOR
-undefine_fhd,cal_base
-cal_base=cal
-cal_base.gain = Pointer_copy(cal.gain)
-cal_base.skymodel = Pointer_copy(cal.skymodel)
+cal_base=Pointer_copy(cal)
 
 IF Keyword_Set(bandpass_calibrate) THEN BEGIN
     cal_bandpass=vis_cal_bandpass(cal,obs,cal_remainder=cal_remainder,file_path_fhd=file_path_fhd,_Extra=extra)

--- a/fhd_utils/IDL_tools/pointer_copy.pro
+++ b/fhd_utils/IDL_tools/pointer_copy.pro
@@ -3,12 +3,13 @@ FUNCTION pointer_copy,param
 type=size(param,/type)
 CASE type OF
     8: BEGIN ;structure type
+        param_out = param
         FOR t_i=0L,N_tags(param)-1 DO BEGIN
             type1=size(param.(t_i),/type)
             IF (type1 EQ 8) OR (type1 EQ 10) THEN BEGIN
-                param_out=pointer_copy(param.(t_i))
+                param_out.(t_i)=pointer_copy(param.(t_i))
             ENDIF ELSE BEGIN
-                param_out = param
+                param_out.(t_i) = param.(t_i)
             ENDELSE
         ENDFOR
     END
@@ -16,7 +17,7 @@ CASE type OF
         IF N_Elements(param) EQ 1 THEN param_out=Ptr_new() ELSE param_out=Ptrarr(size(param,/dimension))
         ptr_i=where(Ptr_valid(param),n_valid)
         FOR p_i=0L,n_valid-1 DO BEGIN
-            param_out[p_i] = Ptr_new(pointer_copy(*param[ptr_i[p_i]]))
+            param_out[ptr_i[p_i]] = Ptr_new(pointer_copy(*param[ptr_i[p_i]]))
         ENDFOR
     END
     ELSE: param_out = param

--- a/fhd_utils/IDL_tools/pointer_copy.pro
+++ b/fhd_utils/IDL_tools/pointer_copy.pro
@@ -1,7 +1,29 @@
-FUNCTION pointer_copy,ptr_in
+FUNCTION pointer_copy,param
 
-IF N_Elements(ptr_in) EQ 1 THEN ptr_out=Ptr_new() ELSE ptr_out=Ptrarr(size(ptr_in,/dimension))
+type=size(param,/type)
+CASE type OF
+    8: BEGIN ;structure type
+        FOR t_i=0L,N_tags(param)-1 DO BEGIN
+            type1=size(param.(t_i),/type)
+            IF (type1 EQ 8) OR (type1 EQ 10) THEN BEGIN
+                param_out=pointer_copy(param.(t_i))
+            ENDIF ELSE BEGIN
+                param_out = param
+            ENDELSE
+        ENDFOR
+    END
+    10: BEGIN ;pointer type
+        IF N_Elements(param) EQ 1 THEN param_out=Ptr_new() ELSE param_out=Ptrarr(size(param,/dimension))
+        ptr_i=where(Ptr_valid(param),n_valid)
+        FOR p_i=0L,n_valid-1 DO BEGIN
+            param_out[p_i] = Ptr_new(pointer_copy(*param[ptr_i[p_i]]))
+        ENDFOR
+    END
+    ELSE: param_out = param
+ENDCASE
 
-FOR dim_i=0L,N_Elements(ptr_in)-1 DO IF Ptr_valid(ptr_in[dim_i]) THEN ptr_out[dim_i]=Ptr_new(*ptr_in[dim_i]) 
-RETURN,ptr_out
+;IF N_Elements(ptr_in) EQ 1 THEN ptr_out=Ptr_new() ELSE ptr_out=Ptrarr(size(ptr_in,/dimension))
+;
+;FOR dim_i=0L,N_Elements(ptr_in)-1 DO IF Ptr_valid(ptr_in[dim_i]) THEN ptr_out[dim_i]=Ptr_new(*ptr_in[dim_i]) 
+RETURN,param_out
 END


### PR DESCRIPTION
It looks like the extended source information was accidentally being erased during calibration. This happened after model visibilities are created for calibration, so the visibilities should have still been correct. Please check that this branch fixes the problem for you.