### PR TITLE
/readonly for uvfits read

### DIFF
--- a/fhd_core/visibility_manipulation/uvfits_read.pro
+++ b/fhd_core/visibility_manipulation/uvfits_read.pro
@@ -24,7 +24,7 @@ ENDIF ELSE BEGIN
     ENDIF
     
     t_readfits=Systime(1)
-    lun = fxposit(file_path_vis, 0)
+    lun = fxposit(file_path_vis, 0,/readonly)
     data_struct=mrdfits(lun,0,data_header0,/silent)
     hdr=vis_header_extract(data_header0, params = data_struct.params,error=error,_Extra=extra)    
     IF Keyword_Set(error) THEN RETURN


### PR DESCRIPTION
To get around some permissions issues, I set a readonly flag to the header/uvfits reader. I don't think we'd ever be in a situation where we would like anything other than readonly, but I wanted to check before I pushed to master.