### PR TITLE
Wrapper defaults

### DIFF
--- a/Observations/eor_firstpass_versions.pro
+++ b/Observations/eor_firstpass_versions.pro
@@ -25,85 +25,6 @@ pro eor_firstpass_versions
   endelse
   cmd_args={version:version}
   
-  ; Set default values for everything
-  calibrate_visibilities=1
-  recalculate_all=0
-  cleanup=0
-  ps_export=0
-  split_ps_export=1
-  combine_healpix=0
-  deconvolve=0
-  mapfn_recalculate=0
-  healpix_recalculate=0
-  flag_visibilities=0
-  vis_baseline_hist=1
-  silent=0
-  save_visibilities=1
-  calibration_visibilities_subtract=0
-  snapshot_healpix_export=1
-  n_avg=2
-  ps_kbinsize=0.5
-  ps_kspan=600.
-  image_filter_fn='filter_uv_uniform'
-  deconvolution_filter='filter_uv_uniform'
-  
-  uvfits_version=5 ;updated by RB, 12/16
-  uvfits_subversion=1
-  
-  catalog_file_path=filepath('MRC_full_radio_catalog.fits',root=rootdir('FHD'),subdir='catalog_data')
-  calibration_catalog_file_path=filepath('mwa_calibration_source_list.sav',root=rootdir('FHD'),subdir='catalog_data')
-  
-  dimension=2048
-  max_sources=20000
-  pad_uv_image=1.
-  FoV=0
-  no_ps=1
-  min_baseline=1.
-  min_cal_baseline=50.
-  ring_radius=10.*pad_uv_image
-  nfreq_avg=16
-  no_rephase=1
-  combine_obs=0
-  smooth_width=32.
-  bandpass_calibrate=1
-  calibration_polyfit=2
-  no_restrict_cal_sources=1
-  restrict_hpx_inds=1
-  
-  kbinsize=0.5
-  psf_resolution=100
-  
-  ; some new defaults (possibly temporary)
-  beam_model_version=2
-  dipole_mutual_coupling_factor=1
-  calibration_flag_iterate = 0
-  
-  no_calibration_frequency_flagging=1
-  
-  ; even newer defaults
-  export_images=1
-  cal_reflection_mode_theory=150
-  cal_reflection_hyperresolve=1
-  model_catalog_file_path=filepath('mwa_calibration_source_list.sav',root=rootdir('FHD'),subdir='catalog_data')
-  model_visibilities=0
-  return_cal_visibilities=1
-  allow_sidelobe_cal_sources=1
-  allow_sidelobe_model_sources=1
-  
-  beam_offset_time=56 ; make this a default. But it won't compound with setting it directly in a version so I think it's ok.
-  
-  ;New defaults - July2015
-  diffuse_calibrate=filepath('EoR0_diffuse_model_94.sav',root=rootdir('FHD'),subdir='catalog_data')
-  cable_bandpass_fit=1
-  cal_bp_transfer=1
-  
-  ;Defaults added - July2016
-  cal_amp_degree_fit=2
-  cal_phase_degree_fit=1
-  
-  ;Defaults added - Nov2016
-  calibration_catalog_file_path = filepath('master_sgal_cat.sav',root=rootdir('FHD'),subdir='catalog_data')
-  
   case version of
   
     ;;; Adam's versions!!! Only Adam may edit this section!!!
@@ -2024,7 +1945,9 @@ undefine, uvfits_subversion, uvfits_version
 fhd_file_list=fhd_path_setup(vis_file_list,version=version,output_directory=output_directory)
 healpix_path=fhd_path_setup(output_dir=output_directory,subdir='Healpix',output_filename='Combined_obs',version=version)
 
-extra=var_bundle() ; bundle all the variables into a structure
+; Set global defaults and bundle all the variables into a structure.
+; Any keywords set on the command line or in the top-level wrapper will supercede these defaults
+eor_wrapper_defaults,extra
 
 fhd_depreciation_test, _Extra=extra
 

--- a/Observations/eor_wrapper_defaults.pro
+++ b/Observations/eor_wrapper_defaults.pro
@@ -1,0 +1,89 @@
+PRO eor_wrapper_defaults,extra
+  ; Set the default settings for all EOR observations.
+  ; This file can be copied and modified for other types of observations, under a new name.
+  ; The defaults set in this file will be overridden 
+
+
+  ; Set default values for everything
+  calibrate_visibilities=1
+  recalculate_all=0
+  cleanup=0
+  ps_export=0
+  split_ps_export=1
+  combine_healpix=0
+  deconvolve=0
+  mapfn_recalculate=0
+  healpix_recalculate=0
+  flag_visibilities=0
+  vis_baseline_hist=1
+  silent=0
+  save_visibilities=1
+  calibration_visibilities_subtract=0
+  snapshot_healpix_export=1
+  n_avg=2
+  ps_kbinsize=0.5
+  ps_kspan=600.
+  image_filter_fn='filter_uv_uniform'
+  deconvolution_filter='filter_uv_uniform'
+  
+  uvfits_version=5 ;updated by RB, 12/16
+  uvfits_subversion=1
+  
+  catalog_file_path=filepath('MRC_full_radio_catalog.fits',root=rootdir('FHD'),subdir='catalog_data')
+  calibration_catalog_file_path=filepath('mwa_calibration_source_list.sav',root=rootdir('FHD'),subdir='catalog_data')
+  
+  dimension=2048
+  max_sources=20000
+  pad_uv_image=1.
+  FoV=0
+  no_ps=1
+  min_baseline=1.
+  min_cal_baseline=50.
+  ring_radius=10.*pad_uv_image
+  nfreq_avg=16
+  no_rephase=1
+  combine_obs=0
+  smooth_width=32.
+  bandpass_calibrate=1
+  calibration_polyfit=2
+  no_restrict_cal_sources=1
+  cal_cable_reflection_fit=150
+  restrict_hpx_inds=1
+  
+  kbinsize=0.5
+  psf_resolution=100
+  
+  ; some new defaults (possibly temporary)
+  beam_model_version=2
+  dipole_mutual_coupling_factor=1
+  calibration_flag_iterate = 0
+  
+  no_calibration_frequency_flagging=1
+  
+  ; even newer defaults
+  export_images=1
+  ;cal_cable_reflection_correct=150
+  cal_cable_reflection_mode_fit=150
+  model_catalog_file_path=filepath('mwa_calibration_source_list.sav',root=rootdir('FHD'),subdir='catalog_data')
+  model_visibilities=0
+  return_cal_visibilities=1
+  allow_sidelobe_cal_sources=1
+  allow_sidelobe_model_sources=1
+  
+  beam_offset_time=56 ; make this a default. But it won't compound with setting it directly in a version so I think it's ok.
+  
+  ;New defaults - July2015
+  diffuse_calibrate=filepath('EoR0_diffuse_model_94.sav',root=rootdir('FHD'),subdir='catalog_data')
+  cable_bandpass_fit=1
+  saved_run_bp=1
+  
+  ;Defaults added - July2016
+  cal_amp_degree_fit=2
+  cal_phase_degree_fit=1
+  
+  ;Defaults added - Nov2016
+  calibration_catalog_file_path = filepath('master_sgal_cat.sav',root=rootdir('FHD'),subdir='catalog_data')
+  
+  extra=var_bundle(level=0) ; first gather all variables set in the top-level wrapper
+  extra=var_bundle(level=1) ; next gather all variables set in this file, removing any duplicates.
+END


### PR DESCRIPTION
`eor_firstpass_versions.pro` has become unwieldy. The intent was to have all commonly used settings in one place so that everyone would use the correct defaults and only change what was needed for their run, but over the years it has grown to the point that rebasing branches is a mess. Instead, I have written a new procedure that contains the general defaults to be used by all standard EOR runs, and individuals or projects can create wrappers that set only the parameters they need, and call  `eor_wrapper_defaults` to set any remaining needed parameters to default values.