### PR TITLE
Eor bubble fixes

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -261,6 +261,10 @@ WARNING! Options in this section may change without notice, and should never be 
   -*EoR_firstpass settings*: not set <br />
   -*Default*: not set <br />
 
+## EoR Bubble Simulations
+
+**bubble_fname**: Specify the path to an HDF5 file containing at least "spectral_info/spectrum" and "spectral_info/freq" of shapes (Npix, Nchan) and (Nchan,), respectively. The "spectrum" object is a set of healpix maps vs frequency representing a full sky EoR signal. <br />
+**select_radius_multiplier**: A circular region is selected from the input healpix maps, corresponding with the primary beam radius. This sets the selection radius to (primary_beam_radius)x(select_radius_multiplier) <br />
 
 ## Diffuse
 

--- a/fhd_core/HEALPix/healpix_interpolate.pro
+++ b/fhd_core/HEALPix/healpix_interpolate.pro
@@ -53,9 +53,12 @@ IF Keyword_Set(from_kelvin) THEN pixel_area_cnv=convert_kelvin_jansky(1.,nside=n
 ;pixel_area_cnv=1.
 
 area_ratio=(4.*!Pi/n_hpx)/((obs.degpix*!DtoR)^2.)
-IF area_ratio GT 1 THEN BEGIN
+print, 'area_ratio',area_ratio
+area_ratio = round(area_ratio*1e6)/1e6 
+IF area_ratio GE 1 THEN BEGIN
     ;beam_area=!Pi*beam_width^2./(4.*Alog(2.)) ;area under a 2D gaussian with given FWHM 
     gauss_width=Sqrt(area_ratio*(4.*Alog(2.))/!Pi);/(2.*Sqrt(2.*Alog(2.)))
+    gauss_width /= 4.    ; Make it smaller
     grid_struct=source_comp_init(xvals=xv_hpx,yvals=yv_hpx,flux=0.)
     grid_struct.flux.(0)=1.
     weights_img=source_image_generate(grid_struct,obs,pol=0,restored_beam_width=gauss_width)

--- a/fhd_utils/modified_astro/pixel_area.pro
+++ b/fhd_utils/modified_astro/pixel_area.pro
@@ -46,6 +46,11 @@ FOR i=0,2 DO BEGIN
     area_map+=(pix_vec_A[*,*,A_i]*pix_vec_B[*,*,B_i]-pix_vec_A[*,*,B_i]*pix_vec_B[*,*,A_i])^2.
 ENDFOR
 area_map=Sqrt(area_map)
+if Keyword_Set(nside) THEN BEGIN
+    print, "Using nside="+String(nside)
+    area_map *= 0.0
+    hpx_area = 4*!Pi / (12.0 * nside*nside)    ; nside^2 evaluates to 0 if nside is integer
+    area_map += hpx_area
 IF Keyword_Set(relative) THEN area_map/=(obs.degpix*!DtoR)^2.
 
 ;astr=obs.astr

--- a/fhd_utils/primary_beam_radius.pro
+++ b/fhd_utils/primary_beam_radius.pro
@@ -1,4 +1,4 @@
-FUNCTION primary_beam_radius, obs, psf, beam_threshold=beam_threshold, _Extra=extra
+FUNCTION primary_beam_radius, obs, psf, beam_threshold=beam_threshold, select_radius_multiplier=select_radius_multiplier,_Extra=extra
   ;Approximate width of circular primary beam, out to some threshold
 
   if not keyword_set(beam_threshold) then beam_threshold = 0.05
@@ -19,7 +19,7 @@ FUNCTION primary_beam_radius, obs, psf, beam_threshold=beam_threshold, _Extra=ex
   beam_primary_i=region_grow(beam,obs_i,threshold=[Max(beam)/2.<beam_threshold,Max(beam)>1.])
   boundary=find_boundary(beam_primary_i,xsize=dimension, ysize=elements,perim_area=perim_area)
   select_radius = degpix*sqrt(perim_area)/2   ;Primary beam radius
-
+  if keyword_set(select_radius_multiplier) THEN select_radius *= select_radius_multiplier
 return, select_radius
 
 END

--- a/simulation/array_simulator.pro
+++ b/simulation/array_simulator.pro
@@ -2,7 +2,7 @@ PRO array_simulator,vis_arr,vis_weights,obs,status_str,psf,params,jones,error=er
     instrument=instrument,cleanup=cleanup,recalculate_all=recalculate_all,$
     n_pol=n_pol,silent=silent,tile_flag_list=tile_flag_list,$
     file_path_fhd=file_path_fhd,freq_start=freq_start,freq_end=freq_end,$
-    eor_sim=eor_sim, include_noise = include_noise, $
+    eor_sim=eor_sim, include_noise = include_noise,select_radius_multiplier=select_radius_multiplier, $
     include_catalog_sources = include_catalog_sources, source_array=source_array,$
     catalog_file_path=catalog_file_path,snapshot_healpix_export=snapshot_healpix_export, export_images=export_images, $
     snapshot_recalculate=snapshot_recalculate,grid_recalculate=grid_recalculate,eor_uvf_cube_file=eor_uvf_cube_file,_Extra=extra
@@ -53,8 +53,7 @@ PRO array_simulator,vis_arr,vis_weights,obs,status_str,psf,params,jones,error=er
   IF Keyword_Set(t_beam) THEN IF ~silent THEN print,'Beam modeling time: ',t_beam
 
   ;; Get a selection radius based on the primary beam width
-  select_radius = primary_beam_radius(obs,psf,beam_threshold=beam_threshold,_Extra=extra)
-
+  select_radius = primary_beam_radius(obs,psf,beam_threshold=beam_threshold,select_radius_multiplier=select_radius_multiplier,_Extra=extra)
   vis_weights=Ptrarr(n_pol,/allocate)
   n_param=N_Elements(params.uu)
   FOR pol_i=0,n_pol-1 DO BEGIN

--- a/simulation/eor_bubble_sim.pro
+++ b/simulation/eor_bubble_sim.pro
@@ -32,14 +32,20 @@ freq_inds = where((freq_hpx GT lim[0]) and (freq_hpx LT lim[1]) )
 freq_hpx = freq_hpx[freq_inds]
 nfreq_hpx = n_elements(freq_hpx)
 
+; making the coord array for h5s_select
+;coord_arr = array_indices(make_array(nfreq_hpx,npix_sel),findgen(nfreq_hpx*npix_sel))
+;coord_arr[1,*] = inds_select[coord_arr[1,*]]
+
 ;; Extract only these healpix indices from the file.
-;H5S_SELECT_ELEMENTS, dspace_id_eor, hpx_inds, /RESET
+; Somehow this ended up being slower than reading in the full array, so leave it out for now.
+;H5S_SELECT_ELEMENTS, dspace_id_eor, coord_arr, /RESET
 
 print, "Reading HDF5 file with EoR Healpix Cube"
 t0 = systime(/seconds)
 if n_elements(dat) eq 0 then dat = H5D_READ(dset_id_eor, FILE_SPACE=dpsace_id_eor)
 print, 'HDF5 reading time = ', systime(/seconds) - t0, ' seconds'
 
+; dat now contains zeros for the nonselected healpix indices, but retains the full shell shape
 ; Interpolate in frequency:
 dat_interp = Fltarr(obs.n_freq,npix_sel)
 t0=systime(/seconds)

--- a/simulation/eor_bubble_sim.pro
+++ b/simulation/eor_bubble_sim.pro
@@ -1,9 +1,7 @@
-FUNCTION eor_bubble_sim, obs, jones, select_radius=select_radius, bubble_fname=bubble_fname, beam_threshold=beam_threshold, allow_sidelobe_sources=allow_sidelobe_sources, dat=dat 
+FUNCTION eor_bubble_sim, obs, jones, select_radius=select_radius, bubble_fname=bubble_fname, dat=dat 
 
 ;Opening an HDF5 file and extract relevant data
 if keyword_set(bubble_fname) THEN hdf5_fname = bubble_fname ELSE message, "Missing bubble file path"
-if not keyword_set(beam_threshold) then beam_threshold = 0.05
-if keyword_set(allow_sidelobe_sources) THEN beam_threshold = 0.01
 if not keyword_set(select_radius) THEN  select_radius = 20     ; Degrees
 
 dimension=obs.dimension
@@ -63,8 +61,8 @@ print, 'Healpix_interpolate timing: ', systime(/seconds) - t0
 FOR pol_i=0, n_pol-1 DO *model_uv_arr[pol_i]=Fltarr(obs.dimension,obs.elements,obs.n_freq)
 FOR fi=0, obs.n_freq-1 do begin
    model_tmp=Ptrarr(n_pol,/allocate)
-   *model_tmp[0] = *model_stokes_arr[fi]
-   *model_tmp[1] = fltarr(obs.dimension, obs.elements)
+   FOR pol_i=1,n_pol-1 DO *model_tmp[pol_i]=Fltarr(obs.dimension,obs.elements)
+   *model_tmp[0] = *model_stokes_arr[fi]      ; model_stokes_arr is Stokes I
    model_arr = stokes_cnv(model_tmp, jones, /inverse)
    Ptr_free, model_tmp
 

--- a/simulation/simulation_wrappers/eor_simulation_slurm_job.sh
+++ b/simulation/simulation_wrappers/eor_simulation_slurm_job.sh
@@ -26,7 +26,7 @@ obsids=("$@")
 obs_id=${obsids[$SLURM_ARRAY_TASK_ID]}
 
 #ls $outdir > /dev/null # ping the output directory so nfs automounts
-/usr/local/bin/idl -IDL_DEVICE ps -IDL_CPU_TPOOL_NTHREADS $ncores -e sim_versions_wrapper -args $obs_id $outdir $version $sim_id 
+/usr/local/bin/idl -IDL_DEVICE ps -IDL_CPU_TPOOL_NTHREADS $ncores -e sim_versions_wrapper -args $obs_id $outdir $version $sim_id
 
 if [ $? -eq 0 ]
 then

--- a/simulation/simulation_wrappers/sim_pipe_slurm.sh
+++ b/simulation/simulation_wrappers/sim_pipe_slurm.sh
@@ -233,7 +233,7 @@ done
 nobs=${#good_obs_list[@]}
 
 #### !!! The -w flag chooses a specific node.
-message=$(sbatch --qos=pri-alanman  --mem=$mem -t ${wallclock_time} -n ${ncores} --array=0-$(( $nobs - 1 ))%20 --export=ncores=$ncores,outdir=$outdir,version=$version,sim_id=$sim_id,thresh=$thresh -o ${fhddir}/grid_out/array_sim-%A_%a.out -e ${fhddir}/grid_out/array_sim-%A_%a.err ${FHDpath}simulation/simulation_wrappers/eor_simulation_slurm_job.sh ${good_obs_list[@]})
+message=$(sbatch  --mem=$mem -t ${wallclock_time} -n ${ncores} --array=0-$(( $nobs - 1 ))%20 --export=ncores=$ncores,outdir=$outdir,version=$version,sim_id=$sim_id,thresh=$thresh -o ${fhddir}/grid_out/array_sim-%A_%a.out -e ${fhddir}/grid_out/array_sim-%A_%a.err ${FHDpath}simulation/simulation_wrappers/eor_simulation_slurm_job.sh ${good_obs_list[@]})
 
 #echo $message
 
@@ -279,7 +279,7 @@ if [ -z ${ending_obs} ]; then
 elif [ -z ${starting_obs} ]; then
 	    ${PSpath}ps_wrappers/ps_slurm.sh -s ${starting_obs} -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
 else
-    ${PSpath}ps_wrappers/ps_slurm.sh -f $obs_file_name -d $outdir/fhd_$version -w ${wallclock_time} -m ${mem}
+    ${PSpath}ps_wrappers/ps_slurm.sh -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
 fi
 
 

--- a/simulation/simulation_wrappers/sim_pipe_slurm.sh
+++ b/simulation/simulation_wrappers/sim_pipe_slurm.sh
@@ -39,7 +39,7 @@ unset resubmit_index
 #######Gathering the input arguments and applying defaults if necessary
 
 #Parse flags for inputs
-while getopts ":f:s:e:o:v:i:p:w:n:m:t" option
+while getopts ":f:s:e:o:v:i:p:w:n:m:q:t" option
 do
    case $option in
 	f) obs_file_name="$OPTARG";;	#text file of observation id's
@@ -51,6 +51,7 @@ do
 	w) wallclock_time=$OPTARG;;	#Time for execution in slurm
 	n) ncores=$OPTARG;;		#Number of cores for slurm
 	m) mem=$OPTARG;;		#Memory per node for slurm
+    q) qos=$OPTARG;;        # Quality of service for Oscar
 	t) firstpass_only=1;;	#Firstpass only, or also do power spectrum?
 	\?) echo "Unknown option: Accepted flags are -f (obs_file_name), -s (starting_obs), -e (ending obs), -o (output directory), "
 	    echo "-v (version input for FHD), -w (wallclock time in slurm), -n (number of cores to use),"
@@ -73,19 +74,11 @@ if [ -z ${obs_file_name} ]; then
    exit 1
 fi
 
-#Update the user on which obsids will run given the inputs
-if [ -z ${starting_obs} ] 
-then
-    echo Starting at observation at beginning of file $obs_file_name
-else
-    echo Starting on observation $starting_obs
-fi
+obs_file_name=$(readlink -f $obs_file_name)   # Get the complete absolute path
 
-if [ -z ${ending_obs} ]
+if [ -z ${qos} ]
 then
-    echo Ending at observation at end of file $obs_file_name
-else
-    echo Ending on observation $ending_obs
+    qos='jpober-condo'
 fi
 
 #firstpass_only specification
@@ -176,19 +169,17 @@ else
     min=${obs_id_array[0]}
 fi
 
-#
-#
 #If minimum not specified, start at minimum of obs_file
 if [ -z ${starting_obs} ]
 then
-   echo "Starting observation not specified: Starting at minimum of $obs_file_name"
+   echo "Starting observation not specified: Starting at minimum of "$(basename $obs_file_name)""
    starting_obs=$min
 fi
 
 #If maximum not specified, end at maximum of obs_file
 if [ -z ${ending_obs} ]
 then
-   echo "Ending observation not specified: Ending at maximum of $obs_file_name"
+   echo "Ending observation not specified: Ending at maximum of "$(basename $obs_file_name)""
    ending_obs=$max
 fi
 
@@ -197,7 +188,7 @@ fi
 unset good_obs_list
 startflag=0
 endflag=0
-#echo $starting_obs
+
 for obs_id in "${obs_id_array[@]}"; do 
      if [ $obs_id == $starting_obs ]; then 
      	startflag=1
@@ -206,25 +197,14 @@ for obs_id in "${obs_id_array[@]}"; do
      	good_obs_list+=($obs_id)
      fi
      if [ $obs_id == $ending_obs ]; then
-	endflag=1
+    	endflag=1
      fi
 done	
 
-#echo ${good_obs_list[@]}
+echo ${good_obs_list[@]}
 
-#for obs_id in "${obs_id_array[@]}"; do
-#    if [[ "$obs_id" =~ ^[0-9]+$ ]]; then      #Allow for non-numeric ObsIds
-#      if [ $obs_id -ge $starting_obs ] && [ $obs_id -le $ending_obs ]; then
-#	  good_obs_list+=($obs_id)
-#      fi
-#    else
-#      good_obs_list+=($obs_id)
-#    fi
-#done
 
 #######End of gathering the input arguments and applying defaults if necessary
-
-
 
 
 #######Submit the job and wait for output
@@ -233,7 +213,7 @@ done
 nobs=${#good_obs_list[@]}
 
 #### !!! The -w flag chooses a specific node.
-message=$(sbatch  --mem=$mem -t ${wallclock_time} -n ${ncores} --array=0-$(( $nobs - 1 ))%20 --export=ncores=$ncores,outdir=$outdir,version=$version,sim_id=$sim_id,thresh=$thresh -o ${fhddir}/grid_out/array_sim-%A_%a.out -e ${fhddir}/grid_out/array_sim-%A_%a.err ${FHDpath}simulation/simulation_wrappers/eor_simulation_slurm_job.sh ${good_obs_list[@]})
+message=$(sbatch --qos=$qos  --mem=$mem -t ${wallclock_time} -n ${ncores} --array=0-$(( $nobs - 1 ))%20 --export=ncores=$ncores,outdir=$outdir,version=$version,sim_id=$sim_id,thresh=$thresh -o ${fhddir}/grid_out/array_sim-%A_%a.out -e ${fhddir}/grid_out/array_sim-%A_%a.err ${FHDpath}simulation/simulation_wrappers/eor_simulation_slurm_job.sh ${good_obs_list[@]})
 
 #echo $message
 
@@ -248,7 +228,6 @@ while [ `myq | grep $id | wc -l` -ge 1 ]; do
     sleep 10
 done
 
-
 ########End of submitting the firstpass job and waiting for output
 
 if [ $firstpass_only -eq 1 ]; then
@@ -259,28 +238,29 @@ if [ $firstpass_only -eq 1 ]; then
 	exit 0
 fi
 
-
 # Submit a job to convert model visibilities to uvfits and MIRIAD formats
 curdir=`pwd -P`
 cd ${fhddir}
 uvconvert.py -o miriad
 cd $curdir
 
-
 ### NOTE this only works if idlstartup doesn't have any print statements (e.g. healpix check)
 PSpath=$(idl -e 'print,rootdir("eppsilon")')
 
-if [ -z ${ending_obs} ]; then
-    if [-z ${starting_obs} ]; then	
+if [ ! -z ${ending_obs} ]; then
+    echo "Ending obs: "${ending_obs}
+    if [ ! -z ${starting_obs} ]; then	
+        echo 'Running ps with both starting and ending obs'
 	    ${PSpath}ps_wrappers/ps_slurm.sh -s ${starting_obs} -e ${ending_obs} -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
     else
+        echo 'Running ps with both ending obs'
 	    ${PSpath}ps_wrappers/ps_slurm.sh -e ${ending_obs} -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
     fi
-elif [ -z ${starting_obs} ]; then
+elif [ ! -z ${starting_obs} ]; then
+        echo 'Running ps with both starting obs'
 	    ${PSpath}ps_wrappers/ps_slurm.sh -s ${starting_obs} -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
 else
     ${PSpath}ps_wrappers/ps_slurm.sh -f $obs_file_name -d ${fhddir} -w ${wallclock_time} -m ${mem}
 fi
-
 
 echo "Cube integration and PS submitted"

--- a/simulation/simulation_wrappers/sim_variation.sh
+++ b/simulation/simulation_wrappers/sim_variation.sh
@@ -25,8 +25,8 @@ do
    case $option in
 	f) obs_id="$OPTARG";;	#Obs_ID
 	p) param_var="$OPTARG";; 	  # String specifying values for a given parameter
-        o) outdir=$OPTARG;;		#output directory for FHD output folder
-        v) version=$OPTARG;;		#FHD folder name and case for variation_versions
+    o) outdir=$OPTARG;;		#output directory for FHD output folder
+    v) version=$OPTARG;;		#FHD folder name and case for variation_versions
 					#Example: nb_foo creates folder named fhd_nb_foo
 	w) wallclock_time=$OPTARG;;	#Time for execution in slurm
 	n) cores=$OPTARG;;		#Number of cores for slurm

--- a/simulation/test_eor_sim.pro
+++ b/simulation/test_eor_sim.pro
@@ -10,7 +10,7 @@ FUNCTION test_eor_sim
 instrument='mwa'
 n_pol=2
 
-bubble_fname='/gpfs/data/jpober/alanman/BubbleCube/TiledHpxCubes/uniform_cube.hdf5'
+bubble_fname='/gpfs/data/jpober/alanman/BubbleCube/TiledHpxCubes/mwa_gaussian_ugrade_256.hdf5'
 select_radius=1.0
 
 ;hdr=uvfits_header_simulate(hdr_in,n_pol=n_pol, instrument=instrument)
@@ -23,6 +23,7 @@ restore, '/users/alanman/fhd_out/fhd_mwa_goldensubset/metadata/1061311664_obs.sa
 obs.dimension=256
 obs.elements=256
 obs.kpix=0.5
+obs.degpix = !RaDeg * 1/(obs.kpix*obs.dimension)
 n_samples=obs.n_time
 n_freq=203
 ;(*obs.baseline_info).freq=findgen(101)*1e6+1e6     ;101 freq chans
@@ -46,9 +47,8 @@ psf=beam_setup(obs)
 jones=fhd_struct_init_jones(obs,status_str,file_path_fhd=file_path_fhd,restore=0)
 
 ;eor_uvf_cube = eor_sim(uv_arr, uv_arr, freq_arr)
-eor_uvf_cube = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname)
+eor_uvf_cube = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname,/ltaper)
 
-exit
 
 model_uvf_arr=Ptrarr(n_pol,/allocate)
 for pol_i=0,n_pol-1 do *model_uvf_arr[pol_i]=Complexarr(obs.dimension,obs.elements, n_freq)

--- a/simulation/test_eor_sim.pro
+++ b/simulation/test_eor_sim.pro
@@ -10,8 +10,8 @@ FUNCTION test_eor_sim
 instrument='mwa'
 n_pol=2
 
-bubble_fname='/gpfs/data/jpober/alanman/BubbleCube/TiledHpxCubes/mwa_patchy_calsky_cube.hdf5'
-select_radius=1.5
+bubble_fname='/gpfs/data/jpober/alanman/BubbleCube/TiledHpxCubes/uniform_cube.hdf5'
+select_radius=1.0
 
 ;hdr=uvfits_header_simulate(hdr_in,n_pol=n_pol, instrument=instrument)
 ;params=uvfits_params_simulate(hdr)
@@ -47,6 +47,8 @@ jones=fhd_struct_init_jones(obs,status_str,file_path_fhd=file_path_fhd,restore=0
 
 ;eor_uvf_cube = eor_sim(uv_arr, uv_arr, freq_arr)
 eor_uvf_cube = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname)
+
+exit
 
 model_uvf_arr=Ptrarr(n_pol,/allocate)
 for pol_i=0,n_pol-1 do *model_uvf_arr[pol_i]=Complexarr(obs.dimension,obs.elements, n_freq)

--- a/simulation/vis_simulate.pro
+++ b/simulation/vis_simulate.pro
@@ -263,18 +263,16 @@ FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=fil
           
           if max(abs(*this_model_uv[0])) eq 0 and max(abs(*this_model_uv[1])) eq 0 then continue
           
- ;         this_model_ptr=vis_source_model(skymodel,obs,status_str,psf,params,this_vis_weight_ptr,model_uv_arr=this_model_uv,$
- ;           timing=model_timing,silent=silent,error=error,_Extra=extra)
-          model_timing=0.0
-    ; vis_source_model is inexplicably taking a long time. Since the uvf cube was already FFTed, just run visibility_degrid.
-          FOR pol_i=0,n_pol-1 DO BEGIN
+           ;this_model_ptr=vis_source_model(skymodel,obs,status_str,psf,params,this_vis_weight_ptr,model_uv_arr=this_model_uv,$
+           ;timing=model_timing,silent=silent,error=error,_Extra=extra)
+           model_timing=0.0
+           ;vis_source_model is inexplicably taking a long time. Since the uvf cube was already FFTed, just run visibility_degrid.
+           FOR pol_i=0,n_pol-1 DO BEGIN
               (*vis_model_arr[pol_i])[fi,*] = (*(visibility_degrid(*this_model_uv[pol_i],this_vis_weight_ptr[pol_i],obs,psf,params,timing=timing,silent=silent,$
                   polarization=pol_i,_Extra=extra)))[fi,*]
                model_timing += timing
           ENDFOR
           print, 'model loop num, timing(s):'+ number_formatter(fi) + ' , ' + number_formatter(model_timing)
-          
-;          for pol_i=0,n_pol-1 do (*vis_model_arr[pol_i])[fi,*] = (*this_model_ptr[pol_i])[fi,*]
           
           undefine_fhd, this_vis_weight_ptr, this_model_ptr, this_model_uv
         endfor

--- a/simulation/vis_simulate.pro
+++ b/simulation/vis_simulate.pro
@@ -263,18 +263,18 @@ FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=fil
           
           if max(abs(*this_model_uv[0])) eq 0 and max(abs(*this_model_uv[1])) eq 0 then continue
           
-          this_model_ptr=vis_source_model(skymodel,obs,status_str,psf,params,this_vis_weight_ptr,model_uv_arr=this_model_uv,$
-            timing=model_timing,silent=silent,error=error,_Extra=extra)
-        ;  model_timing=0.0
-    ; vis_source_model uses DFT, which works for point source models. Since the uvf cube was already FFTed, just run visibility_degrid.
-        ;  FOR pol_i=0,n_pol-1 DO BEGIN
-        ;      (*vis_model_arr[pol_i])[fi,*] = (*(visibility_degrid(*this_model_uv[pol_i],this_vis_weight_ptr[pol_i],obs,psf,params,timing=timing,silent=silent,$
-        ;          polarization=pol_i,_Extra=extra)))[fi,*]
-        ;       model_timing += timing
-        ;  ENDFOR
+ ;         this_model_ptr=vis_source_model(skymodel,obs,status_str,psf,params,this_vis_weight_ptr,model_uv_arr=this_model_uv,$
+ ;           timing=model_timing,silent=silent,error=error,_Extra=extra)
+          model_timing=0.0
+    ; vis_source_model is inexplicably taking a long time. Since the uvf cube was already FFTed, just run visibility_degrid.
+          FOR pol_i=0,n_pol-1 DO BEGIN
+              (*vis_model_arr[pol_i])[fi,*] = (*(visibility_degrid(*this_model_uv[pol_i],this_vis_weight_ptr[pol_i],obs,psf,params,timing=timing,silent=silent,$
+                  polarization=pol_i,_Extra=extra)))[fi,*]
+               model_timing += timing
+          ENDFOR
           print, 'model loop num, timing(s):'+ number_formatter(fi) + ' , ' + number_formatter(model_timing)
           
-          for pol_i=0,n_pol-1 do (*vis_model_arr[pol_i])[fi,*] = (*this_model_ptr[pol_i])[fi,*]
+;          for pol_i=0,n_pol-1 do (*vis_model_arr[pol_i])[fi,*] = (*this_model_ptr[pol_i])[fi,*]
           
           undefine_fhd, this_vis_weight_ptr, this_model_ptr, this_model_uv
         endfor

--- a/simulation/vis_simulate.pro
+++ b/simulation/vis_simulate.pro
@@ -1,7 +1,7 @@
 FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=file_path_fhd,vis_weights=vis_weights,$
     recalculate_all=recalculate_all,$
     include_eor=include_eor, flat_sigma = flat_sigma, no_distrib = no_distrib, delta_power = delta_power, $
-    bubble_fname=bubble_fname, select_radius=select_radius, ltaper=ltaper, $
+    bubble_fname=bubble_fname, select_radius=select_radius, ltaper=ltaper,orthomap_var=orthomap_var, $
     delta_uv_loc = delta_uv_loc, eor_real_sky = eor_real_sky, $
     include_noise = include_noise, noise_sigma_freq = noise_sigma_freq, $
     include_catalog_sources = include_catalog_sources, source_array=source_array, catalog_file_path=catalog_file_path, $
@@ -161,7 +161,7 @@ FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=fil
     
     ;; If bubble file is included, add to the model_uvf_arr
     IF Keyword_Set(bubble_fname) THEN BEGIN 
-       bubble_uvf = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname,ltaper=ltaper)
+       bubble_uvf = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname,ltaper=ltaper,file_path_fhd=file_path_fhd,orthomap_var=orthomap_var)
        IF Min(Ptr_valid(bubble_uvf)) GT 0 THEN BEGIN
          IF n_elements(model_uvf_arr) GT 0 then begin
            FOR pol_i=0,n_pol-1 DO *model_uvf_arr[pol_i] += *bubble_uvf[pol_i];*uv_mask_use

--- a/simulation/vis_simulate.pro
+++ b/simulation/vis_simulate.pro
@@ -1,7 +1,7 @@
 FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=file_path_fhd,vis_weights=vis_weights,$
     recalculate_all=recalculate_all,$
     include_eor=include_eor, flat_sigma = flat_sigma, no_distrib = no_distrib, delta_power = delta_power, $
-    bubble_fname=bubble_fname, select_radius=select_radius, $
+    bubble_fname=bubble_fname, select_radius=select_radius, ltaper=ltaper, $
     delta_uv_loc = delta_uv_loc, eor_real_sky = eor_real_sky, $
     include_noise = include_noise, noise_sigma_freq = noise_sigma_freq, $
     include_catalog_sources = include_catalog_sources, source_array=source_array, catalog_file_path=catalog_file_path, $
@@ -161,7 +161,7 @@ FUNCTION vis_simulate,obs,status_str,psf,params,jones,skymodel,file_path_fhd=fil
     
     ;; If bubble file is included, add to the model_uvf_arr
     IF Keyword_Set(bubble_fname) THEN BEGIN 
-       bubble_uvf = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname)
+       bubble_uvf = eor_bubble_sim(obs, jones, select_radius=select_radius, bubble_fname=bubble_fname,ltaper=ltaper)
        IF Min(Ptr_valid(bubble_uvf)) GT 0 THEN BEGIN
          IF n_elements(model_uvf_arr) GT 0 then begin
            FOR pol_i=0,n_pol-1 DO *model_uvf_arr[pol_i] += *bubble_uvf[pol_i];*uv_mask_use


### PR DESCRIPTION
The most significant change in this branch is that I _correctly_ form the uvf cube in eor_bubble_sim so that the degridding step actually loops over frequency. For the sake of computational speed, I also switch back to using visibility_degrid instead of its wrapper (vis_source_model) in vis_simulate. There was some discussion back in January about the differences of these two, and it might be worth reexamining vis_simulate.