### PR TITLE
ignoring max_cal_baseline bug fix

### DIFF
--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -121,7 +121,9 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
         IF min_cal_baseline GT min_baseline THEN taper_min=((Sqrt(2.)*min_cal_baseline-dist_arr)/min_cal_baseline)>0. ELSE taper_min=0. 
         IF max_cal_baseline LT max_baseline THEN taper_max=((dist_arr-max_cal_baseline)/min_cal_baseline)>0. ELSE taper_max=0.
         baseline_weights=(1.-(taper_min+taper_max)^2.)>0.
-      ENDIF ELSE flag_dist_cut=where((dist_arr LT min_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
+      ENDIF ELSE BEGIN
+        flag_dist_cut=where((dist_arr LT min_cal_baseline) OR (dist_arr GT max_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
+      ENDELSE
     ENDIF ELSE BEGIN
       vis_weight_use=0>*vis_weight_ptr_use[pol_i]<1
       IF Keyword_Set(preserve_visibilities) THEN vis_model=*vis_model_ptr[pol_i] $

--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -143,7 +143,7 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
         IF min_cal_baseline GT min_baseline THEN taper_min=((Sqrt(2.)*min_cal_baseline-dist_arr)/min_cal_baseline)>0. ELSE taper_min=0. 
         IF max_cal_baseline LT max_baseline THEN taper_max=((dist_arr-max_cal_baseline)/min_cal_baseline)>0. ELSE taper_max=0.
         baseline_weights=(1.-(taper_min+taper_max)^2.)>0.
-      ENDIF ELSE flag_dist_cut=where((Temporary(dist_arr) LT min_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
+      ENDIF ELSE flag_dist_cut=where((Temporary(dist_arr) LT min_cal_baseline) OR (Temporary(dist_arr) GT max_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
     ENDELSE
     kx_arr=(ky_arr=(dist_arr=0))
     ;***

--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -143,7 +143,7 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
         IF min_cal_baseline GT min_baseline THEN taper_min=((Sqrt(2.)*min_cal_baseline-dist_arr)/min_cal_baseline)>0. ELSE taper_min=0. 
         IF max_cal_baseline LT max_baseline THEN taper_max=((dist_arr-max_cal_baseline)/min_cal_baseline)>0. ELSE taper_max=0.
         baseline_weights=(1.-(taper_min+taper_max)^2.)>0.
-      ENDIF ELSE flag_dist_cut=where((Temporary(dist_arr) LT min_cal_baseline) OR (Temporary(dist_arr) GT max_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
+      ENDIF ELSE flag_dist_cut=where((dist_arr LT min_cal_baseline) OR (dist_arr GT max_cal_baseline) OR (Temporary(xcen) GT dimension/2.) OR (Temporary(ycen) GT elements/2.),n_dist_cut)
     ENDELSE
     kx_arr=(ky_arr=(dist_arr=0))
     ;***


### PR DESCRIPTION
Analog to commit 7ab937e6d62422eeb7c41148d11f00d37084abee that fixed a bug where min_cal_baseline was ignored. This fixes the same bug for max_cal_baseline.