### PR TITLE
Pull n_vis_cal from modified weights

### DIFF
--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -533,6 +533,7 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
       freq_nan_i=nan_i mod n_freq
       freq_nan_i=freq_nan_i[Uniq(freq_nan_i,Sort(freq_nan_i))]
       (*vis_weight_ptr_use[pol_i])[freq_nan_i,*]=0
+      weight[freq_nan_i,*]=0
       gain_arr[nan_i]=0.
       
     ENDIF
@@ -540,7 +541,7 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
     cal_return.convergence[pol_i]=Ptr_new(convergence)
   ENDFOR
   
-  vis_count_i=where(*vis_weight_ptr_use[0],n_vis_cal)
+  vis_count_i=where(weight,n_vis_cal)
   cal_return.n_vis_cal=n_vis_cal
   
   RETURN,cal_return


### PR DESCRIPTION
Currently, n_vis_cal pulls from the weights pointer, which is purposely not modified by baseline cuts. However, this is false advertising: we want to include baseline cuts in the calculation of n_vis_cal. 

The change I pushed pulls it from a modified versions of the weights. I do this after a for loop over the polarizations, so it will grab the n_vis_cal from the YY pol (instead of the XX pol, which was the default before).

Please comment if you have an opinion. 