### PR TITLE
bug fix: beam resolution mismatch

### DIFF
--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -55,7 +55,7 @@ hour_angle = hour_angle mod 360.
 apply_astrometry, obs, ra_arr=obs.obsra, dec_arr=obs.lat, x_arr=x_t, y_arr=y_t, /ad2xy
 apply_astrometry, obs, dec_arr=lat, x_arr=x_t, y_arr=y_t, /xy2ad, /ignore_refraction
 
-obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq, degpix=obs.degpix) ; Use only one average Jones matrix, not one per frequency
+obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq) ; Use only one average Jones matrix, not one per frequency
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
     psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant)
 Jones=antenna[0].Jones[*,*,0]

--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -55,7 +55,7 @@ hour_angle = hour_angle mod 360.
 apply_astrometry, obs, ra_arr=obs.obsra, dec_arr=obs.lat, x_arr=x_t, y_arr=y_t, /ad2xy
 apply_astrometry, obs, dec_arr=lat, x_arr=x_t, y_arr=y_t, /xy2ad, /ignore_refraction
 
-obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq) ; Use only one average Jones matrix, not one per frequency
+obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq, degpix=obs.degpix) ; Use only one average Jones matrix, not one per frequency
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
     psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant)
 Jones=antenna[0].Jones[*,*,0]

--- a/fhd_core/setup_metadata/fhd_struct_update_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_update_obs.pro
@@ -29,17 +29,18 @@ freq_bin_i=fltarr(n_freq)
 FOR bin=0L,nfreq_bin-1 DO IF freq_ri[bin] LT freq_ri[bin+1] THEN freq_bin_i[freq_ri[freq_ri[bin]:freq_ri[bin+1]-1]]=bin
 freq_center=Median(frequency_array)
 
+IF N_Elements(dimension) EQ 0 THEN dimension = obs.dimension
+IF N_Elements(elements) EQ 0 THEN elements = obs.elements
 IF Keyword_Set(FoV) THEN kbinsize=!RaDeg/FoV
-IF ~Keyword_Set(kbinsize) THEN kbinsize=0.5 ;k-space resolution, in wavelengths per pixel
-IF N_Elements(degpix) EQ 0 THEN k_span=2.*max_baseline ELSE k_span=!RaDeg/degpix 
-dimension_test=2.^Round(ALOG10(k_span/kbinsize)/ALOG10(2.))
-
-max_baseline=max_baseline<(k_span/sqrt(2.))
-
-IF N_Elements(dimension) EQ 0 THEN dimension=dimension_test ELSE dimension=Float(dimension);dimension of the image in pixels; dimension = x direction
-IF N_Elements(elements) EQ 0 THEN elements=dimension ELSE elements=Float(elements);elements = y direction
-degpix=!RaDeg/(kbinsize*dimension) ;image space resolution, in degrees per pixel
-k_span=Sqrt(dimension*elements/2.)
+IF Keyword_Set(kbinsize) THEN BEGIN
+    degpix=!RaDeg/(kbinsize*dimension) ;image space resolution, in degrees per pixel
+ENDIF ELSE BEGIN
+    IF ~Keyword_Set(degpix) THEN BEGIN
+        degpix = obs.degpix
+    ENDIF
+    kbinsize=!RaDeg/(degpix*dimension) ;k-space resolution, in wavelengths per pixel
+ENDELSE
+k_span = (dimension > elements)*kbinsize
 max_baseline=max_baseline<(k_span/sqrt(2.))
 
 struct=obs


### PR DESCRIPTION
This pull request resolves issue #153, where imaging was failing when max_baseline was small.

Imaging failed because the Jones matrix was infinite. This came from line 69 in fhd_struct_init_jones.pro, where power_zenith was being set to 0. In line 70, the Jones matrix is divided by power_zenith, leading to infinite values and NANs for the visibilities. In line 69 power_zenith_beam has a resolution of 2048 and obs_temp.zenx and obs_temp.zeny were each ~128. After the fix obs_temp.zenx and obs_temp.zeny are ~1024 and the interpolation in line 69 gives a non-zero value.