### PR TITLE
Make the Jones matrix double precision and correct a Stokes conversion bug

### DIFF
--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -21,12 +21,12 @@ IF Keyword_Set(update_last) THEN BEGIN
     p_map=Ptrarr(4,4,/allocate)
     p_corr=Ptrarr(4,4,/allocate)
     FOR pol_i2=0,3 DO FOR pol_i1=0,3 DO BEGIN
-        temp=fltarr(dimension_in,elements_in)
+        temp=dblarr(dimension_in,elements_in)
         temp[jones_in.inds]=*jones_in.Jmat[pol_i1,pol_i2]
         temp=Rebin(temp,dimension,elements)
         *p_map[pol_i1,pol_i2]=temp[inds_use]
         
-        temp=fltarr(dimension_in,elements_in)
+        temp=dblarr(dimension_in,elements_in)
         temp[jones_in.inds]=*jones_in.Jinv[pol_i1,pol_i2]
         temp=Rebin(temp,dimension,elements)
         *p_corr[pol_i1,pol_i2]=temp[inds_use]
@@ -59,10 +59,11 @@ obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq) ; Use only one avera
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
     psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant)
 Jones=antenna[0].Jones[*,*,0]
+
 ; Calculate the normalization
 ant_pol1 = 0
 ant_pol2 = 1
-power_zenith_beam = Fltarr(dimension, elements)
+power_zenith_beam = dblarr(dimension, elements)
 FOR ant_pol=0,1 DO FOR sky_pol=0,1 DO $
     power_zenith_beam += Real_part(*Jones[sky_pol,ant_pol]*Conj(*Jones[sky_pol, ant_pol]))
 power_zenith_beam /= 2.
@@ -71,8 +72,8 @@ FOR ptr_i=0,3 DO *Jones[ptr_i] = (*Jones[ptr_i])[inds_use]/Sqrt(power_zenith)
 
 p_map=Ptrarr(4,4,/allocate)
 p_corr=Ptrarr(4,4,/allocate)
-FOR i=0,3 DO FOR j=0,3 DO *p_map[i,j]=fltarr(n_pix)
-FOR i=0,3 DO FOR j=0,3 DO *p_corr[i,j]=fltarr(n_pix)
+FOR i=0,3 DO FOR j=0,3 DO *p_map[i,j]=dblarr(n_pix)
+FOR i=0,3 DO FOR j=0,3 DO *p_corr[i,j]=dblarr(n_pix)
 order_1 = [0,1,0,1]
 order_2 = [0,1,1,0]
 
@@ -81,7 +82,7 @@ FOR pix=0L,n_pix-1 DO BEGIN
     ;Jmat converts [pp,qq,pq,qp] -> [xx,yy,xy,yx]
     ;Jinv converts [xx, yy, xy, yx] -> [pp, qq, pq, qp]
     ;Note: Stokes [I, Q, U, V] = (1./2.)*[(pp+qq), (qq-pp), (pq+qp), (iqp-ipq)]
-    Jmat = Fltarr(4,4)
+    Jmat = dblarr(4,4)
     FOR ii=0,3 DO BEGIN
         FOR jj = 0,3 DO BEGIN
             Jmat[ii, jj] = (*Jones[order_1[ii], order_1[jj]])[pix]*Conj((*Jones[order_2[ii], order_2[jj]])[pix])

--- a/fhd_core/polarization/stokes_cnv.pro
+++ b/fhd_core/polarization/stokes_cnv.pro
@@ -55,7 +55,7 @@ IF Keyword_Set(inverse) THEN p_use=p_map ELSE p_use=p_corr
 ; U = xy* + yx*
 ; V = ixy* - iyx*
 ; where x is in the RA direction and y is in the Dec direction
-stokes_mat_term1=[1,1,1,complex(0,1)]
+stokes_mat_term1=[1,1,1,complex(0,1)]  ; Elements of the 4x4 Stokes conversion matrix, zeros removed
 stokes_mat_term2=[1,-1,1,-complex(0,1)]
 stokes_inv_term1=[.5,.5,.5,.5]
 stokes_inv_term2=[.5,-.5,-complex(0,.5),complex(0,.5)]

--- a/fhd_core/polarization/stokes_cnv.pro
+++ b/fhd_core/polarization/stokes_cnv.pro
@@ -49,6 +49,12 @@ ENDELSE
 n_pix=N_Elements(inds)
 IF Keyword_Set(inverse) THEN p_use=p_map ELSE p_use=p_corr
 
+; Define the Stokes conversion:
+; I = xx* + yy*
+; Q = xx* - yy*
+; U = xy* + yx*
+; V = ixy* - iyx*
+; where x is in the RA direction and y is in the Dec direction
 stokes_mat_term1=[1,1,1,complex(0,1)]
 stokes_mat_term2=[1,-1,1,-complex(0,1)]
 stokes_inv_term1=[.5,.5,.5,.5]

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -44,9 +44,9 @@ CASE beam_model_version OF
             Jmat1=mrdfits(file_path_J_matrix,ext_i,header,status=status,/silent)
             IF ext_i EQ 0 THEN BEGIN
                 n_ang=Float(sxpar(header,'NAXIS2'))
-                Jmat_arr=Complexarr(n_ext,n_ant_pol,n_ant_pol,n_ang)
-                theta_arr=Fltarr(n_ext,n_ang)
-                phi_arr=Fltarr(n_ext,n_ang)
+                Jmat_arr=Dcomplexarr(n_ext,n_ant_pol,n_ant_pol,n_ang)
+                theta_arr=Dblarr(n_ext,n_ang)
+                phi_arr=Dblarr(n_ext,n_ang)
             ENDIF
             theta_arr[ext_i,*]=Jmat1[0,*] ;zenith angle in degrees
             phi_arr[ext_i,*]=Jmat1[1,*] ;azimuth angle in degrees, clockwise from East
@@ -72,7 +72,7 @@ CASE beam_model_version OF
         
     ;    Jmat_return=Ptrarr(n_ant_pol,n_ant_pol)
         Jmat_interp=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
-        FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO Jmat_interp[p_i,p_j,freq_i]=Ptr_new(Complexarr(n_ang))
+        FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO Jmat_interp[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(n_ang))
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR a_i=0L,n_ang-1 DO BEGIN
             Jmat_single_ang=Interpol(Jmat_arr[*,p_i,p_j,a_i],freq_arr_Jmat,freq_center);*norm_factor
             FOR freq_i=0L,nfreq_bin-1 DO (*Jmat_interp[p_i,p_j,freq_i])[a_i]=Jmat_single_ang[freq_i]
@@ -91,7 +91,7 @@ CASE beam_model_version OF
         IF n_horizon_test GT 0 THEN horizon_mask[horizon_test]=0  
         Jones_matrix=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO $
-            Jones_matrix[p_i,p_j,freq_i]=Ptr_new(Complexarr(psf_image_dim,psf_image_dim))
+            Jones_matrix[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(psf_image_dim,psf_image_dim))
             
         interp_res=obs.degpix
         angle_slice_i0=Uniq(phi_arr)


### PR DESCRIPTION
This pull request changes the Jones matrix to double precision, from float. It also includes a bug fix for the Stokes conversion.

These changes were motivated by work done on the Stokes_basis_coordinates branch. We found that Stokes I source modeling depended on the coordinate system. This dependency was due to machine precision errors and disappeared when we began using a double precision Jones matrix. 

Here is a power spectrum difference plot of master minus double_precision_beam:
![fhd_rlb_averemove_swbh_dencorr__testing_before_stokes_convert_fix_Apr2019_1061316296_minus_test_double_precision_beam_branch_May2019_1061316296_2dkpower](https://user-images.githubusercontent.com/12840057/57660236-75022900-759a-11e9-858e-8d20ed67ba48.png)
