### PR TITLE
Rework the power beam calculation

### DIFF
--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -21,7 +21,7 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   power_zenith_beam=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
     (abs(*Jones2[0,ant_pol2])^2.+abs(*Jones2[1,ant_pol2])^2.))
   power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)
-  power_beam = power_zenith_beam*beam_ant1*beam_ant2
+  power_beam = power_zenith_beam*beam_ant1*Conj(beam_ant2)
 
   image_power_beam=power_beam/power_zenith
   if keyword_set(kernel_window) then image_power_beam *= *(antenna1.pix_window)

--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -21,7 +21,7 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   power_zenith_beam=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
     (abs(*Jones2[0,ant_pol2])^2.+abs(*Jones2[1,ant_pol2])^2.))
   power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)
-  power_beam = power_zenith_beam*beam_ant1*Conj(beam_ant2)
+  power_beam = power_zenith_beam*beam_ant1*beam_ant2
 
   image_power_beam=power_beam/power_zenith
   if keyword_set(kernel_window) then image_power_beam *= *(antenna1.pix_window)

--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -18,6 +18,9 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   beam_ant2=DComplex(Conj(*(antenna2.response[ant_pol2,freq_i])))
   beam_norm=1.
   
+  ;Amplitude of the response from ant1 is Sqrt(|J1[0,pol1]|^2 + |J1[1,pol1]|^2)
+  ;Amplitude of the response from ant2 is Sqrt(|J2[0,pol2]|^2 + |J2[1,pol2]|^2)
+  ;Amplitude of the baseline response is the product of the antenna responses
   power_zenith_beam=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
     (abs(*Jones2[0,ant_pol2])^2.+abs(*Jones2[1,ant_pol2])^2.))
   power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)

--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -17,31 +17,11 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   beam_ant1=DComplex(*(antenna1.response[ant_pol1,freq_i]))
   beam_ant2=DComplex(Conj(*(antenna2.response[ant_pol2,freq_i])))
   beam_norm=1.
-
-  IF ant_pol1 NE ant_pol2 THEN BEGIN
-    power_zenith_beam1=abs((*Jones1[0,ant_pol1])*(Conj(*Jones2[0,ant_pol1]))+$
-      (*Jones1[1,ant_pol1])*(Conj(*Jones2[1,ant_pol1])))
-    power_zenith1=Interpolate(power_zenith_beam1,zen_int_x,zen_int_y,cubic=-0.5)
-    power_zenith_beam2=abs((*Jones1[0,ant_pol2])*(Conj(*Jones2[0,ant_pol2]))+$
-      (*Jones1[1,ant_pol2])*(Conj(*Jones2[1,ant_pol2])))
-    power_zenith2=Interpolate(power_zenith_beam2,zen_int_x,zen_int_y,cubic=-0.5)
-    power_zenith=Sqrt(power_zenith1*power_zenith2)
-
-    power_beam1=(*Jones1[0,ant_pol1]*beam_ant1)*(Conj(*Jones2[0,ant_pol1])*beam_ant2)+$
-      (*Jones1[1,ant_pol1]*beam_ant1)*(Conj(*Jones2[1,ant_pol1])*beam_ant2)
-    power_beam2=(*Jones1[0,ant_pol2]*beam_ant1)*(Conj(*Jones2[0,ant_pol2])*beam_ant2)+$
-      (*Jones1[1,ant_pol2]*beam_ant1)*(Conj(*Jones2[1,ant_pol2])*beam_ant2)
-    power_beam=Sqrt(power_beam1*power_beam2)
-    debug_point=1
-  ENDIF ELSE BEGIN
-    power_zenith_beam=abs((*Jones1[0,ant_pol1])*(Conj(*Jones2[0,ant_pol2]))+$
-      (*Jones1[1,ant_pol1])*(Conj(*Jones2[1,ant_pol2])))
-    power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)
-    ;power_zenith=abs((*Jones1[0,ant_pol1])[zen_int_x,zen_int_y]*(Conj(*Jones2[0,ant_pol2]))[zen_int_x,zen_int_y]+$
-    ;             (*Jones1[1,ant_pol1])[zen_int_x,zen_int_y]*(Conj(*Jones2[1,ant_pol2]))[zen_int_x,zen_int_y])
-    power_beam=(*Jones1[0,ant_pol1]*beam_ant1)*(Conj(*Jones2[0,ant_pol2])*beam_ant2)+$
-      (*Jones1[1,ant_pol1]*beam_ant1)*(Conj(*Jones2[1,ant_pol2])*beam_ant2)
-  ENDELSE
+  
+  power_zenith_beam=Sqrt(((*Jones1[0,ant_pol1])^2.+(*Jones1[1,ant_pol1])^2.)*$
+    ((Conj(*Jones2[0,ant_pol2]))^2.+(Conj(*Jones2[1,ant_pol2]))^2.))
+  power_zenith=Interpolate(abs(power_zenith_beam),zen_int_x,zen_int_y,cubic=-0.5)
+  power_beam = power_zenith_beam*beam_ant1*beam_ant2
 
   image_power_beam=power_beam/power_zenith
   if keyword_set(kernel_window) then image_power_beam *= *(antenna1.pix_window)

--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -18,9 +18,9 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   beam_ant2=DComplex(Conj(*(antenna2.response[ant_pol2,freq_i])))
   beam_norm=1.
   
-  power_zenith_beam=Sqrt(((*Jones1[0,ant_pol1])^2.+(*Jones1[1,ant_pol1])^2.)*$
-    ((Conj(*Jones2[0,ant_pol2]))^2.+(Conj(*Jones2[1,ant_pol2]))^2.))
-  power_zenith=Interpolate(abs(power_zenith_beam),zen_int_x,zen_int_y,cubic=-0.5)
+  power_zenith_beam=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
+    (abs(*Jones2[0,ant_pol2])^2.+abs(*Jones2[1,ant_pol2])^2.))
+  power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)
   power_beam = power_zenith_beam*beam_ant1*beam_ant2
 
   image_power_beam=power_beam/power_zenith


### PR DESCRIPTION
Fix to calculate the power beam from the Jones matrix correctly. This change has a small impact on the power spectrum. 

Here is the difference power spectrum from Aug 23, 2013, master minus branch:
![fhd_rlb_test_averemove_swbh_dencorr__master_branch_May2019_Aug23_combined_minus_beam_power_polarized_calculation_branch_Jun2019_Aug23_combined_2dkpower](https://user-images.githubusercontent.com/12840057/59786998-7e1b9f80-9296-11e9-82f0-c56bd71133d2.png)
And here is the power spectrum ratio:
![fhd_rlb_test_averemove_swbh_dencorr__master_branch_May2019_Aug23_combined_diffratio_beam_power_polarized_calculation_branch_Jun2019_Aug23_combined_2dkpower](https://user-images.githubusercontent.com/12840057/59787030-8ffd4280-9296-11e9-90c6-8e59f2f520fc.png)

This change affects the beam at a level of ~10^-5. Here is the beam from master minus the beam from the branch for a zenith pointing:
![beam_diff](https://user-images.githubusercontent.com/12840057/59787072-b02d0180-9296-11e9-821f-e7849959c18c.png)
and for a non-zenith pointing:
![beam_diff_off_zenith](https://user-images.githubusercontent.com/12840057/59787093-bf13b400-9296-11e9-9572-7762736d4a3c.png)
Note that these beams are peak-normalized to 1.
