### PR TITLE
Stokes V calculation fix

### DIFF
--- a/fhd_core/gridding/dirty_image_generate.pro
+++ b/fhd_core/gridding/dirty_image_generate.pro
@@ -76,7 +76,9 @@ IF Keyword_Set(image_filter_fn) THEN BEGIN
     ENDCASE
 ENDIF
 
-IF not Keyword_Set(double_flag) THEN dirty_image=Float(dirty_image)
+IF not Keyword_Set(double_flag) THEN BEGIN
+    IF Keyword_Set(no_real) THEN dirty_image=Complex(dirty_image) ELSE dirty_image=Float(dirty_image)
+ENDIF
 IF Keyword_Set(normalization) THEN dirty_image*=normalization
 RETURN,dirty_image
 END

--- a/fhd_core/gridding/vis_split_export_multi.pro
+++ b/fhd_core/gridding/vis_split_export_multi.pro
@@ -20,7 +20,10 @@ FOR obs_i=0,n_obs-1 DO BEGIN
     IF obs_i EQ 0 THEN obs_arr=Replicate(obs,n_obs) ELSE obs_arr[obs_i]=obs
 ENDFOR
 
-n_pol=Min(obs_arr.n_pol)
+; We don't use the cross polarizations currently.
+; To use them in the future, the healpix cubes will need to be complex for XY and YX
+; See crosspol_reformat.pro for details on the way XY and YX are stored
+n_pol=Min(obs_arr.n_pol) < 2
 n_freq=Min(obs_arr.n_freq)
 IF N_Elements(n_avg) EQ 0 THEN n_avg=Float(Round(n_freq/48.)) ;default of 48 output frequency bins
 n_freq_use=Floor(n_freq/n_avg)

--- a/fhd_core/polarization/crosspol_reformat.pro
+++ b/fhd_core/polarization/crosspol_reformat.pro
@@ -4,10 +4,8 @@ icomp = Complex(0,1)
 IF n_pol EQ 4 THEN BEGIN
     IF not Keyword_Set(inverse) THEN BEGIN
         crosspol_image = (*image_uv_arr[2] + conjugate_mirror(*image_uv_arr[3]))/2.
-        pseudo_stokes_U = (crosspol_image + conjugate_mirror(crosspol_image))/2.
-        pseudo_stokes_V = -icomp * (crosspol_image - conjugate_mirror(crosspol_image))/2.
-        *image_uv_arr[2] = pseudo_stokes_U + pseudo_stokes_V
-        *image_uv_arr[3] = pseudo_stokes_U - pseudo_stokes_V
+        *image_uv_arr[2] = crosspol_image
+        *image_uv_arr[3] = conjugate_mirror(crosspol_image)
     ENDIF ELSE BEGIN
         pseudo_stokes_U = (*image_uv_arr[2] + *image_uv_arr[3])/2.
         pseudo_stokes_V = (*image_uv_arr[2] - *image_uv_arr[3])/2.

--- a/fhd_core/polarization/crosspol_reformat.pro
+++ b/fhd_core/polarization/crosspol_reformat.pro
@@ -2,16 +2,13 @@ FUNCTION crosspol_reformat, image_uv_arr, inverse=inverse
 n_pol=Total(ptr_valid(image_uv_arr))
 icomp = Complex(0,1)
 IF n_pol EQ 4 THEN BEGIN
-    IF not Keyword_Set(inverse) THEN BEGIN
-        crosspol_image = (*image_uv_arr[2] + conjugate_mirror(*image_uv_arr[3]))/2.
-        *image_uv_arr[2] = crosspol_image
-        *image_uv_arr[3] = conjugate_mirror(crosspol_image)
-    ENDIF ELSE BEGIN
-        pseudo_stokes_U = (*image_uv_arr[2] + *image_uv_arr[3])/2.
-        pseudo_stokes_V = (*image_uv_arr[2] - *image_uv_arr[3])/2.
-        *image_uv_arr[2] = pseudo_stokes_U + icomp * pseudo_stokes_V
-        *image_uv_arr[3] = pseudo_stokes_U - icomp * pseudo_stokes_V
+    IF not Keyword_Set(inverse) THEN BEGIN ;instrumental -> Stokes
+        crosspol_image = (*image_uv_arr[2] + conjugate_mirror(*image_uv_arr[3]))/2. 
+    ENDIF ELSE BEGIN ;Stokes -> instrumental
+        crosspol_image = (2.*(*image_uv_arr[2]) - conjugate_mirror(*image_uv_arr[3]))
     ENDELSE
+    *image_uv_arr[2] = crosspol_image
+    *image_uv_arr[3] = conjugate_mirror(crosspol_image)
 ENDIF
 RETURN,image_uv_arr
 END

--- a/fhd_core/polarization/stokes_cnv.pro
+++ b/fhd_core/polarization/stokes_cnv.pro
@@ -191,7 +191,7 @@ ENDIF ELSE BEGIN ;else case is array of images
         
     ENDIF ELSE BEGIN ;instrumental -> Stokes
         FOR sky_pol=0,n_pol-1 DO BEGIN
-            image_arr_sky[sky_pol]=Ptr_new(fltarr(dimension,elements))
+            image_arr_sky[sky_pol]=Ptr_new(Dcomplexarr(dimension,elements))
             FOR instr_pol=0,n_pol-1 DO BEGIN
                 (*image_arr_sky[sky_pol])[inds]+=(*image_arr[instr_pol]*weight_invert(*beam_use[instr_pol]))[inds]*(*p_corr[instr_pol,sky_pol])
             ENDFOR

--- a/fhd_output/crosspol_split_real_imaginary.pro
+++ b/fhd_output/crosspol_split_real_imaginary.pro
@@ -1,0 +1,14 @@
+PRO crosspol_split_real_imaginary, image_ptr_array, pol_names=pol_names
+
+n_pol=N_Elements(image_ptr_array)
+IF n_pol EQ 4 THEN BEGIN
+    crosspol_image = *image_ptr_array[2]
+    image_ptr_array[2] = Ptr_new((Real_part(crosspol_image))
+    image_ptr_array[3] = Ptr_new(Imaginary(crosspol_image))
+ENDIF
+IF N_Elements(pol_names) GE 4 THEN BEGIN
+    crosspol_name = pol_names[2]
+    pol_names[2] = crosspol_name + '_real'
+    pol_names[3] = crosspol_name + '_imaginary'
+ENDIF
+END

--- a/fhd_output/crosspol_split_real_imaginary.pro
+++ b/fhd_output/crosspol_split_real_imaginary.pro
@@ -3,7 +3,7 @@ PRO crosspol_split_real_imaginary, image_ptr_array, pol_names=pol_names
 n_pol=N_Elements(image_ptr_array)
 IF n_pol EQ 4 THEN BEGIN
     crosspol_image = *image_ptr_array[2]
-    image_ptr_array[2] = Ptr_new((Real_part(crosspol_image))
+    image_ptr_array[2] = Ptr_new(Real_part(crosspol_image))
     image_ptr_array[3] = Ptr_new(Imaginary(crosspol_image))
 ENDIF
 IF N_Elements(pol_names) GE 4 THEN BEGIN


### PR DESCRIPTION
These changes resolve a bug that made the Stokes V images identically zero. Previously, the XY and YX maps were constrained to be real, which forced Stokes V to be zero. These changes allow for complex XY and YX maps and resolve an error gridding those maps. They affect the Stokes images only. The branch has been tested and it has no impact on the power spectrum.