### PR TITLE
Add beam to source list

### DIFF
--- a/fhd_core/deconvolution/fast_holographic_deconvolution.pro
+++ b/fhd_core/deconvolution/fast_holographic_deconvolution.pro
@@ -398,21 +398,16 @@ converge_check2=converge_check2[0:iter-1]
 converge_check=converge_check[0:i2]
 
 ; Section 3: Cull deconvolved clean components, and condense valid components to form a final source catalog
-fhd_params.convergence=Stddev(image_use[where(beam_mask*source_mask)],/nan)
-noise_map=fhd_params.convergence*beam_corr_avg
-noise_map=Rebin(noise_map,dimension,elements)
-beam_width=beam_width_calculate(obs,min_restored_beam_width=1.,/FWHM)
-IF Keyword_Set(independent_fit) THEN noise_map*=Sqrt(n_pol)
-comp_i_use=where(component_array.flux.I GT 0)
-component_array=component_array[comp_i_use]
-fhd_params.n_iter=iter
-fhd_params.n_components=N_Elements(component_array)
 fhd_params.detection_threshold=detection_threshold
+fhd_params.convergence=Stddev(image_use[where(beam_mask*source_mask)],/nan)
+fhd_params.n_iter=iter
 source_n_arr=source_n_arr[0:iter-1]
 detection_threshold_arr=detection_threshold_arr[0:iter-1]
-source_mask=Rebin(source_mask,dimension,elements,/sample)
-source_array=components2sources(component_array,obs,fhd_params,radius=beam_width>1.5,noise_map=noise_map,$
-    gain_factor=gain_factor,source_mask=source_mask,_Extra=extra)
+
+source_array = process_deconvolution_components(component_array,obs,fhd_params,noise_map,$
+    independent_fit=independent_fit,gain_factor=gain_factor,source_mask=source_mask,_Extra=extra)
+
+fhd_params.n_components=N_Elements(component_array)
 fhd_params.n_sources=N_Elements(source_array)
 info_struct={convergence_iter:converge_check2,source_n_iter:source_n_arr,detection_threshold_iter:detection_threshold_arr}
 fhd_params.info=Ptr_new(info_struct)

--- a/fhd_core/deconvolution/source_detection/process_deconvolution_components.pro
+++ b/fhd_core/deconvolution/source_detection/process_deconvolution_components.pro
@@ -23,5 +23,15 @@ source_mask=Rebin(source_mask,dimension,elements,/sample)
 source_array=components2sources(component_array,obs,fhd_params,radius=beam_width>1.5,noise_map=noise_map,$
     gain_factor=gain_factor,source_mask=source_mask,_Extra=extra)
 
+; Add beam information to the source and component lists
+FOR pol_i=0,n_pol-1 DO BEGIN
+    beam_use = sqrt(*beam_arr[pol_i])
+    component_array.beam.(pol_i) = beam_use[Round(component_array.x), Round(component_array.y)]
+    source_array.beam.(pol_i) = beam_use[Round(source_array.x), Round(source_array.y)]
+    ;also convert extended source components.
+    extend_i=where(Ptr_valid(source_array.extend),n_ext)
+    FOR ext_i=0L,n_ext-1 DO *(source_array[extend_i[ext_i]].extend).beam.(pol_i) = source_array[extend_i[ext_i]].beam.(pol_i)
+ENDFOR
+
 RETURN source_array
 END

--- a/fhd_core/deconvolution/source_detection/process_deconvolution_components.pro
+++ b/fhd_core/deconvolution/source_detection/process_deconvolution_components.pro
@@ -1,0 +1,27 @@
+FUNCTION process_deconvolution_components,component_array,obs,fhd_params,noise_map,beam_arr=beam_arr,$
+    independent_fit=independent_fit,gain_factor=gain_factor,source_mask=source_mask,_Extra=extra
+
+dimension = obs.dimension
+elements = obs.elements
+n_pol = obs.n_pol
+
+beam_width=beam_width_calculate(obs,min_restored_beam_width=1.,/FWHM)
+; Note that beam_arr contains the power beam, i.e. the beam squared
+beam_avg = *beam_arr[0]
+IF n_pol GT 1 THEN BEGIN
+    beam_avg += *beam_arr[1]
+    beam_avg /= 2.
+ENDIF
+beam_avg = sqrt(beam_avg)
+
+noise_map=fhd_params.convergence*weight_invert(beam_avg, fhd_params.beam_threshold)
+IF Keyword_Set(independent_fit) THEN noise_map*=Sqrt(n_pol)
+
+comp_i_use=where(component_array.flux.I GT 0)
+component_array=component_array[comp_i_use]
+source_mask=Rebin(source_mask,dimension,elements,/sample)
+source_array=components2sources(component_array,obs,fhd_params,radius=beam_width>1.5,noise_map=noise_map,$
+    gain_factor=gain_factor,source_mask=source_mask,_Extra=extra)
+
+RETURN source_array
+END

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -5,9 +5,10 @@ IF N_Elements(n_sources) EQ 0 THEN $
     n_sources=Max([N_Elements(xvals),N_Elements(yvals),N_Elements(ra),N_Elements(dec),1.])
 
 flux_struct={flux,xx:0.,yy:0.,xy:Complex(0.),yx:Complex(0.),I:0.,Q:0.,U:0.,V:0.}
+beam_struct={beam,xx:0.,yy:0.,xy:Complex(0.),yx:Complex(0.),I:0.,Q:0.,U:0.,V:0.}
 ;flux order is 0-3: xx, yy, xy, yx in apparent brightness; 4-7: I, Q, U, V in sky brightness
 ;flag type codes are 0: no flag, 1: low confidence 2: sidelobe contamination
-struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),flux:flux_struct}
+struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),flux:flux_struct, beam:beam_struct}
 source_comp_new=Replicate(struct_base,n_sources>1)
 
 IF Keyword_Set(xvals) THEN source_comp_new.x=xvals


### PR DESCRIPTION
This collects a few modifications to the source and component lists at the end of deconvolution and moves those to a new function. I then also add a new tag to those structures to contain the beam value at the location of the source or component, and include that calculation in the new function. So far, this is only calculated at the end of deconvolution, though it could be added for the source arrays used in calibration.
Old code should safely ignore the new information in the source array.