### PR TITLE
Fix source structure bug

### DIFF
--- a/fhd_core/calibration/generate_source_cal_list.pro
+++ b/fhd_core/calibration/generate_source_cal_list.pro
@@ -27,9 +27,8 @@ ENDIF ELSE BEGIN
             endelse
         ENDIF
     ENDIF ELSE catalog_path_full=catalog_path
-    
-    cat_init=source_comp_init(n_sources=0) ;define structure BEFORE restoring, in case the definition has changed
-    RESTORE,catalog_path_full,/relaxed ;catalog
+
+    catalog = load_source_catalog(catalog_path_full, varname='catalog')
 ENDELSE
 
 dimension=obs.dimension

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -1,5 +1,5 @@
 FUNCTION source_comp_init,source_comp_in,n_sources=n_sources,xvals=xvals,yvals=yvals,frequency=frequency,$
-    ra=ra,dec=dec,flux=flux,id=id,StoN=StoN,alpha=alpha,extend=extend,gain_factor=gain_factor,overwrite=overwrite
+    ra=ra,dec=dec,flux=flux,id=id,StoN=StoN,alpha=alpha,extend=extend,gain_factor=gain_factor,overwrite=overwrite,_Extra=extra
 
 IF N_Elements(n_sources) EQ 0 THEN $
     n_sources=Max([N_Elements(xvals),N_Elements(yvals),N_Elements(ra),N_Elements(dec),1.])
@@ -23,6 +23,6 @@ IF Keyword_Set(extend) THEN source_comp_new.extend=extend ;extended source compo
 IF Keyword_Set(frequency) THEN IF Mean(frequency) GT 1E5 THEN source_comp_new.freq=frequency/1E6 ELSE source_comp_new.freq=frequency ;frequency in MHz
 IF Keyword_Set(gain_factor) THEN source_comp_new.gain=gain_factor
 
-IF N_Elements(source_comp_in) GT 0 AND ~Keyword_Set(overwrite) THEN source_comp=[source_comp_in,source_comp_new] ELSE source_comp=source_comp_new
+IF Keyword_Set(source_comp_in) AND ~Keyword_Set(overwrite) THEN source_comp=[source_comp_in,source_comp_new] ELSE source_comp=source_comp_new
 RETURN,source_comp
 END  

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -1,5 +1,8 @@
 FUNCTION source_comp_init,source_comp_in,n_sources=n_sources,xvals=xvals,yvals=yvals,frequency=frequency,$
     ra=ra,dec=dec,flux=flux,id=id,StoN=StoN,alpha=alpha,extend=extend,gain_factor=gain_factor,overwrite=overwrite,_Extra=extra
+; NOTE: It is very important that the tags of the source structure be able to autocomplete to the keywords of this function
+; For example, the current xvals is fine, because the .x tag can autocomplete to xvals. If a new x_error (for example)
+; keyword or tag were introduced, this would break load_source_catalog.pro
 
 IF N_Elements(n_sources) EQ 0 THEN $
     n_sources=Max([N_Elements(xvals),N_Elements(yvals),N_Elements(ra),N_Elements(dec),1.])

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -15,7 +15,11 @@ IF Keyword_Set(xvals) THEN source_comp_new.x=xvals
 IF Keyword_Set(yvals) THEN source_comp_new.y=yvals
 IF Keyword_Set(ra) THEN source_comp_new.ra=ra
 IF Keyword_Set(dec) THEN source_comp_new.dec=dec
-IF Keyword_Set(flux) THEN source_comp_new.flux.I=flux 
+IF Keyword_Set(flux) THEN BEGIN
+    IF size(flux,/type) EQ 8 THEN BEGIN ;check if a structure
+        FOR ii=0,7 DO source_comp_new.flux.(ii) = flux.(ii)
+    ENDIF ELSE source_comp_new.flux.I=flux 
+ENDIF
 IF Keyword_Set(StoN) THEN source_comp_new.ston=StoN ;signal to noise
 IF Keyword_Set(id) THEN source_comp_new.id=id ;unique source id
 IF Keyword_Set(alpha) THEN source_comp_new.alpha=alpha ;spectral index

--- a/fhd_core/setup_metadata/load_source_catalog.pro
+++ b/fhd_core/setup_metadata/load_source_catalog.pro
@@ -1,0 +1,70 @@
+FUNCTION load_source_catalog, catalog_filepath, varname=varname
+    ; Restore a source catalog from a .sav file, being careful about changed structure definitions
+
+    IF N_Elements(varname) EQ 0 THEN varname="catalog"
+
+    ;define structure BEFORE restoring, in case the definition has changed
+    cat_init=source_comp_init(n_sources=0)
+    source_cat = getvar_savefile(catalog_filepath, varname, /compatibility_mode)
+
+    extend_i=where(Ptr_valid(source_cat.extend),n_ext,complement=point_i,ncomp=n_point)
+    ignore_tags = ['EXTEND']
+
+    ; If the source list structure definition has changed we have to update the structure ourselves
+    ; compatibility_mode is supposed to take care of that, but does not appear to work for source catalogs
+    source_tags = tag_names(cat_init)
+    restored_tags = tag_names(source_cat)
+    ns_tags = N_Elements(source_tags)
+    nr_tags = N_Elements(restored_tags)
+
+    n_missing = 0
+    n_extra = 0
+    missing_tags = []
+    extra_tags = []
+    good_tag_ids = []
+    good_tag_names = []
+    FOR tag_i=0,ns_tags-1 DO BEGIN
+        IF Max(strmatch(restored_tags,source_tags[tag_i],/fold_case)) EQ 0 THEN BEGIN
+            n_missing += 1
+            missing_tags = [missing_tags, source_tags[tag_i]]
+        ENDIF ELSE BEGIN
+            IF Max(strmatch(ignore_tags,source_tags[tag_i],/fold_case)) EQ 0 THEN BEGIN
+                good_tag_ids = [good_tag_ids, tag_i]
+                good_tag_names = [good_tag_names, source_tags[tag_i]]
+            ENDIF
+        ENDELSE
+    ENDFOR
+    FOR tag_i=0,nr_tags-1 DO BEGIN
+        IF Max(strmatch(source_tags,restored_tags[tag_i],/fold_case)) EQ 0 THEN BEGIN
+            n_extra += 1
+            extra_tags = [extra_tags, restored_tags[tag_i]]
+        ENDIF
+    ENDFOR
+    IF n_missing + n_extra GT 0 THEN BEGIN
+        IF n_missing GT 0 THEN BEGIN
+            print,"WARNING! Mis-matched source list structure definition for file", catalog_filepath
+            print,"Missing tags replaced with default values:", missing_tags
+        ENDIF
+
+        IF n_extra GT 0 THEN BEGIN
+            print,"WARNING! Mis-matched source list structure definition for file", catalog_filepath
+            print,"Extraneous tags have been removed:", extra_tags
+        ENDIF
+        source_cat_mod = fill_source_list(source_cat, good_tag_names, good_tag_ids)
+        FOR ext_i=0,n_ext-1 DO source_cat_mod[extend_i[ext_i]].extend = Ptr_new(fill_source_list(*source_cat[extend_i[ext_i]].extend, good_tag_names, good_tag_ids))
+        RETURN, source_cat_mod
+    ENDIF ELSE RETURN, source_cat
+
+END
+
+
+FUNCTION fill_source_list,source_list_in, tag_names, tag_ids
+    ; Create a new source list structure from only the tags common to both the current definition and the input structure
+
+    FOR tag_i=0,N_Elements(tag_names)-1 DO BEGIN
+        IF N_Elements(struct) EQ 0 THEN struct=create_struct(tag_names[tag_i],source_list_in.(tag_ids[tag_i])) $
+            ELSE struct=create_struct(tag_names[tag_i],source_list_in.(tag_ids[tag_i]),struct)
+    ENDFOR
+    source_list = source_comp_init(_Extra=struct)
+    RETURN, source_list
+END


### PR DESCRIPTION
This fixes a bug where an old source structure restored from a .sav file has incompatible tags with the current definition of the structure. It generates a new source structure, and fills each tag of the structure with values present in the loaded structure. The same treatment is applied to any extended sources. Any missing values are left at their defaults (as defined in `source_comp_init.pro`), and any extraneous tags are discarded. Warning messages in either case are printed to the log.