### PR TITLE
Create keyword debug_equal_beams

### DIFF
--- a/fhd_core/beam_modeling/general_antenna_response.pro
+++ b/fhd_core/beam_modeling/general_antenna_response.pro
@@ -1,4 +1,5 @@
-FUNCTION general_antenna_response,obs,antenna,za_arr=za_arr,az_arr=az_arr,psf_image_dim=psf_image_dim
+FUNCTION general_antenna_response,obs,antenna,za_arr=za_arr,az_arr=az_arr,psf_image_dim=psf_image_dim,$
+    debug_flip=debug_flip, debug_equal_beams=debug_equal_beams, _Extra=extra
 
 n_ant=obs.n_tile
 n_ant_pol=antenna[0].n_pol ;this needs to be the same for all antennas!
@@ -19,8 +20,11 @@ proj_z=Cos(za_arr*!DtoR) & proj_z_use=Reform(proj_z,(psf_image_dim)^2.)
 ;    delays:Ptr_new(),size_meters:0.,height:0.,group_id:Lonarr(n_ant_pol)-1}
 
 group_arr=antenna.group_id
+use_pol = indgen(n_ant_pol)
+if keyword_set(debug_flip) then use_pol[0:1]=[1,0]
+if keyword_set(debug_equal_beams) then use_pol[1]=0
 FOR pol_i=0,n_ant_pol-1 DO BEGIN
-    g_hist=histogram(group_arr[0,*],min=0,/binsize,reverse_ind=g_ri)
+    g_hist=histogram(group_arr[use_pol[pol_i],*],min=0,/binsize,reverse_ind=g_ri)
     n_group=N_Elements(g_hist)
     FOR grp_i=0L,n_group-1 DO BEGIN
         ng=g_hist[grp_i]
@@ -44,9 +48,9 @@ FOR pol_i=0,n_ant_pol-1 DO BEGIN
             response=Complexarr(psf_image_dim,psf_image_dim)
             Kconv=(2.*!Pi)*(freq_center[freq_i]/c_light_vacuum) 
             antenna_gain_arr=Exp(-icomp*Kconv*D_d)
-            voltage_delay=Exp(icomp*2.*!Pi*delays*(freq_center[freq_i])*Reform((*gain[0])[freq_i,*])) 
-            meas_current=(*coupling[0,freq_i])#voltage_delay
-            zenith_norm=Mean((*coupling[0,freq_i])#Replicate(1.,n_ant_elements))
+            voltage_delay=Exp(icomp*2.*!Pi*delays*(freq_center[freq_i])*Reform((*gain[use_pol[pol_i]])[freq_i,*])) 
+            meas_current=(*coupling[use_pol[pol_i],freq_i])#voltage_delay
+            zenith_norm=Mean((*coupling[use_pol[pol_i],freq_i])#Replicate(1.,n_ant_elements))
             meas_current/=zenith_norm
 
             FOR ii=0L,n_ant_elements-1 DO BEGIN

--- a/fhd_core/beam_modeling/general_antenna_response.pro
+++ b/fhd_core/beam_modeling/general_antenna_response.pro
@@ -1,5 +1,5 @@
 FUNCTION general_antenna_response,obs,antenna,za_arr=za_arr,az_arr=az_arr,psf_image_dim=psf_image_dim,$
-    debug_flip=debug_flip, debug_equal_beams=debug_equal_beams, _Extra=extra
+    debug_flip=debug_flip, debug_equal_beams=debug_equal_beams
 
 n_ant=obs.n_tile
 n_ant_pol=antenna[0].n_pol ;this needs to be the same for all antennas!

--- a/fhd_core/beam_modeling/general_antenna_response.pro
+++ b/fhd_core/beam_modeling/general_antenna_response.pro
@@ -20,7 +20,7 @@ proj_z=Cos(za_arr*!DtoR) & proj_z_use=Reform(proj_z,(psf_image_dim)^2.)
 
 group_arr=antenna.group_id
 FOR pol_i=0,n_ant_pol-1 DO BEGIN
-    g_hist=histogram(group_arr[pol_i,*],min=0,/binsize,reverse_ind=g_ri)
+    g_hist=histogram(group_arr[0,*],min=0,/binsize,reverse_ind=g_ri)
     n_group=N_Elements(g_hist)
     FOR grp_i=0L,n_group-1 DO BEGIN
         ng=g_hist[grp_i]
@@ -44,9 +44,9 @@ FOR pol_i=0,n_ant_pol-1 DO BEGIN
             response=Complexarr(psf_image_dim,psf_image_dim)
             Kconv=(2.*!Pi)*(freq_center[freq_i]/c_light_vacuum) 
             antenna_gain_arr=Exp(-icomp*Kconv*D_d)
-            voltage_delay=Exp(icomp*2.*!Pi*delays*(freq_center[freq_i])*Reform((*gain[pol_i])[freq_i,*])) 
-            meas_current=(*coupling[pol_i,freq_i])#voltage_delay
-            zenith_norm=Mean((*coupling[pol_i,freq_i])#Replicate(1.,n_ant_elements))
+            voltage_delay=Exp(icomp*2.*!Pi*delays*(freq_center[freq_i])*Reform((*gain[0])[freq_i,*])) 
+            meas_current=(*coupling[0,freq_i])#voltage_delay
+            zenith_norm=Mean((*coupling[0,freq_i])#Replicate(1.,n_ant_elements))
             meas_current/=zenith_norm
 
             FOR ii=0L,n_ant_elements-1 DO BEGIN

--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -52,7 +52,7 @@ apply_astrometry, obs, dec_arr=lat, x_arr=x_t, y_arr=y_t, /xy2ad, /ignore_refrac
 
 obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq) ; Use only one average Jones matrix, not one per frequency
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
-    psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant)
+    psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant,_Extra=extra)
 Jones=rotate_jones_matrix(obs, antenna[0].Jones[*,*,0])
 
 ; Calculate the normalization

--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -52,7 +52,8 @@ apply_astrometry, obs, dec_arr=lat, x_arr=x_t, y_arr=y_t, /xy2ad, /ignore_refrac
 
 obs_temp = fhd_struct_update_obs(obs, nfreq_avg=obs.n_freq) ; Use only one average Jones matrix, not one per frequency
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
-    psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant,_Extra=extra)
+    psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant,$
+    debug_flip=debug_flip,debug_equal_beams=debug_equal_beams)
 Jones=rotate_jones_matrix(obs, antenna[0].Jones[*,*,0])
 
 ; Calculate the normalization

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -1,6 +1,6 @@
 FUNCTION mwa_beam_setup_gain,obs,antenna,file_path_fhd=file_path_fhd,$
     za_arr=za_arr,az_arr=az_arr,psf_image_dim=psf_image_dim,debug_flip=debug_flip,$
-    _EXTRA = EXTRA 
+    debug_equal_beams=debug_equal_beams, _EXTRA=EXTRA 
 
 n_ant_pol=Max(antenna.n_pol)
 nfreq_bin=Max(antenna.nfreq_bin)
@@ -50,10 +50,10 @@ CASE beam_model_version OF
             ENDIF
             theta_arr[ext_i,*]=Jmat1[0,*] ;zenith angle in degrees
             phi_arr[ext_i,*]=Jmat1[1,*] ;azimuth angle in degrees, clockwise from East
-            Jmat1[6:9,*]=Jmat1[2:5,*]  ;make beams identical
             FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO BEGIN
                 Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
                 if keyword_set(debug_flip) then Jmat_arr[ext_i,p_j,p_i,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
+                if keyword_set(debug_equal_beams) then Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2,*]+icomp*Jmat1[2+p_i*2+1,*]
             ENDFOR
             freq_arr_Jmat[ext_i]=Float(sxpar(header,'FREQ')) ;in Hz
         ENDFOR

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -50,6 +50,7 @@ CASE beam_model_version OF
             ENDIF
             theta_arr[ext_i,*]=Jmat1[0,*] ;zenith angle in degrees
             phi_arr[ext_i,*]=Jmat1[1,*] ;azimuth angle in degrees, clockwise from East
+            Jmat1[6:9,*]=Jmat1[2:5,*]  ;make beams identical
             FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO BEGIN
                 Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
                 if keyword_set(debug_flip) then Jmat_arr[ext_i,p_j,p_i,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -51,9 +51,11 @@ CASE beam_model_version OF
             theta_arr[ext_i,*]=Jmat1[0,*] ;zenith angle in degrees
             phi_arr[ext_i,*]=Jmat1[1,*] ;azimuth angle in degrees, clockwise from East
             FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO BEGIN
-                Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
-                if keyword_set(debug_flip) then Jmat_arr[ext_i,p_j,p_i,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
-                if keyword_set(debug_equal_beams) then Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2,*]+icomp*Jmat1[2+p_i*2+1,*]
+                if ~keyword_set(debug_flip) and ~keyword_set(debug_equal_beams) then $
+                    Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*] else begin
+                    if keyword_set(debug_flip) then Jmat_arr[ext_i,p_j,p_i,*]=Jmat1[2+p_i*2+p_j*4,*]+icomp*Jmat1[2+p_i*2+p_j*4+1,*]
+                    if keyword_set(debug_equal_beams) then Jmat_arr[ext_i,p_i,p_j,*]=Jmat1[2+p_i*2,*]+icomp*Jmat1[2+p_i*2+1,*]
+                endelse
             ENDFOR
             freq_arr_Jmat[ext_i]=Float(sxpar(header,'FREQ')) ;in Hz
         ENDFOR


### PR DESCRIPTION
This PR creates a new keyword that sets the Y beam equal to the X beam for debugging (issue #171). The branch has been tested and works.