### PR TITLE
Add option to turn off plotting calibration solutions

### DIFF
--- a/fhd_core/calibration/vis_calibrate.pro
+++ b/fhd_core/calibration/vis_calibrate.pro
@@ -7,7 +7,7 @@ FUNCTION vis_calibrate,vis_ptr,cal,obs,status_str,psf,params,jones,vis_weight_pt
     flag_calibration=flag_calibration,vis_model_arr=vis_model_arr,$
     calibration_auto_fit=calibration_auto_fit,cal_stop=cal_stop, model_transfer=model_transfer,$
     sim_over_calibrate=sim_over_calibrate,debug_phase_longrun=debug_phase_longrun,sim_perf_calibrate=sim_perf_calibrate,$
-    debug_ave_ref=debug_ave_ref,debug_amp_longrun=debug_amp_longrun,_Extra=extra
+    debug_ave_ref=debug_ave_ref,debug_amp_longrun=debug_amp_longrun,no_png=no_png,_Extra=extra
     
   t0_0=Systime(1)
   error=0
@@ -214,8 +214,10 @@ FUNCTION vis_calibrate,vis_ptr,cal,obs,status_str,psf,params,jones,vis_weight_pt
   basename=file_basename(file_path_fhd)
   dirpath=file_dirname(file_path_fhd)
   image_path=filepath(basename,root=dirpath,sub='output_images')
-  ;make sure to plot both, if autocorrelations are used for the calibration solution
-  plot_cals,cal,obs,cal_res=cal_res,cal_auto=cal_auto,file_path_base=image_path,_Extra=extra
+  IF ~Keyword_Set(no_png) THEN BEGIN
+      ;make sure to plot both, if autocorrelations are used for the calibration solution
+      plot_cals,cal,obs,cal_res=cal_res,cal_auto=cal_auto,file_path_base=image_path,_Extra=extra
+  ENDIF
 
   if keyword_set(debug_phase_longrun) OR keyword_set(debug_amp_longrun) THEN $
     debug_calibration_options,obs, cal, cal_base, debug_phase_longrun=debug_phase_longrun, debug_amp_longrun=debug_amp_longrun

--- a/fhd_output/fhd_quickview.pro
+++ b/fhd_output/fhd_quickview.pro
@@ -310,17 +310,19 @@ ENDIF
 
 IF source_flag THEN source_array_export,source_arr_out,obs_out,beam=beam_avg,stokes_images=stokes_residual_arr,file_path=output_path+'_source_list'
 
-; plot calibration solutions, export to png
-IF size(cal,/type) EQ 8 THEN BEGIN
-   IF cal.skymodel.n_sources GT 0 THEN BEGIN
-      IF file_test(file_path_fhd+'_cal_hist.sav') THEN BEGIN
-         vis_baseline_hist=getvar_savefile(file_path_fhd+'_cal_hist.sav','vis_baseline_hist')
-         plot_cals,cal,obs,file_path_base=image_path,vis_baseline_hist=vis_baseline_hist
-      ENDIF ELSE BEGIN
-         plot_cals,cal,obs,file_path_base=image_path,_Extra=extra
-      ENDELSE
-   ENDIF ELSE plot_cals,cal,obs,file_path_base=image_path,_Extra=extra
-endif
+; plot calibration solutions, export to png if allowed
+IF ~Keyword_Set(no_png) THEN BEGIN
+    IF size(cal,/type) EQ 8 THEN BEGIN
+        IF cal.skymodel.n_sources GT 0 THEN BEGIN
+            IF file_test(file_path_fhd+'_cal_hist.sav') THEN BEGIN
+                vis_baseline_hist=getvar_savefile(file_path_fhd+'_cal_hist.sav','vis_baseline_hist')
+                plot_cals,cal,obs,file_path_base=image_path,vis_baseline_hist=vis_baseline_hist
+            ENDIF ELSE BEGIN
+                plot_cals,cal,obs,file_path_base=image_path,_Extra=extra
+            ENDELSE
+        ENDIF ELSE plot_cals,cal,obs,file_path_base=image_path,_Extra=extra
+    ENDIF
+ENDIF
 
 ;Build a fits header
 mkhdr,fits_header,*instr_dirty_arr[0]
@@ -571,7 +573,7 @@ FOR pol_i=0,n_pol-1 DO BEGIN
         ENDIF
     ENDIF
 ENDFOR
-IF Keyword_Set(output_residual_histogram) THEN $
+IF Keyword_Set(output_residual_histogram) AND ~Keyword_Set(no_png) THEN $
     residual_statistics,(*stokes_residual_arr[0])*beam_mask,obs_out,beam_base=beam_base_out,$
         /center,file_path_base=image_path+filter_name,_Extra=extra
 


### PR DESCRIPTION
The keyword `no_png=1` will now also be passed in to calibration, and will also turn off making .png plots of the calibration solutions.