### PR TITLE
Allow source modeling to be explicitly turned off

### DIFF
--- a/fhd_core/source_modeling/fhd_struct_init_skymodel.pro
+++ b/fhd_core/source_modeling/fhd_struct_init_skymodel.pro
@@ -6,7 +6,7 @@ FUNCTION fhd_struct_init_skymodel,obs,source_list=source_list,catalog_path=catal
 IF N_Elements(return_cal_visibilities) EQ 0 THEN calibration_flag=0 ELSE calibration_flag=return_cal_visibilities
 IF Keyword_Set(galaxy_model) THEN galaxy_flag=1 ELSE galaxy_flag=0
 IF Keyword_Set(diffuse_model) THEN diffuse_filepath=diffuse_model ELSE diffuse_filepath=''
-IF N_Elements(catalog_path) EQ 0 THEN catalog_path_use='' ELSE catalog_path_use=file_basename(catalog_path,'.sav',/fold_case)
+IF Keyword_Set(catalog_path) THEN catalog_path_use=file_basename(catalog_path,'.sav',/fold_case) ELSE catalog_path_use=''
 n_src=N_Elements(source_list)
 IF n_src EQ 0 THEN source_list=source_comp_init(n_sources=0,freq=obs.freq_center)
 IF N_Elements(galaxy_spectral_index) EQ 0 THEN galaxy_spectral_index=!Values.F_NAN


### PR DESCRIPTION
I've tested this branch and it successfully resolves a bug. The bug prevented modeling diffuse emission without also using a point source catalog for modeling, even if the point sources were previously modeled during calibration.