### PR TITLE
Use per-pol image normalization for all image filters

### DIFF
--- a/fhd_output/get_image_renormalization.pro
+++ b/fhd_output/get_image_renormalization.pro
@@ -18,7 +18,6 @@ FOR pol_i=0,n_pol-1 DO BEGIN
     renorm_factor[pol_i]*=((*beam_base[pol_i])[obs.obsx,obs.obsy])^2.
     renorm_factor[pol_i]/=(degpix*!DtoR)^2. ; Convert from Jy/pixel to Jy/sr
 ENDFOR
-renorm_factor[*]=mean(renorm_factor)
 
 RETURN,renorm_factor
 


### PR DESCRIPTION
Using a single normalization across polarizations caused catastrophic errors in imaging when "optimal weighting" (FFT filter "fiter_uv_weighted") is used. PR #181 implemented per-pol image normalization for that weighting scheme only. This PR implements per-pol normalization for all weighting schemes, not just optimal.