### PR TITLE
Document the flipped orientation of the beam in UV space

### DIFF
--- a/fhd_core/beam_modeling/beam_image.pro
+++ b/fhd_core/beam_modeling/beam_image.pro
@@ -1,6 +1,8 @@
 ;+
 ; :Description:
-;    Generates the average beam image for one polarization
+;    Generates the average beam image for one polarization.
+;    Note that the UV->sky transformation uses the inverse FFT for the beam but the forward FFT for the image.
+;    This convention ensures the correct orientation of the UV-space beam for gridding visibilities.
 ;
 ; :Params:
 ;    psf_base_ptr - equal to psf.base standard structure.

--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -30,7 +30,8 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   if keyword_set(kernel_window) then image_power_beam *= *(antenna1.pix_window)
 
   ;Generate UV beam and interpolate to a super resolution
-  psf_base_single=dirty_image_generate(image_power_beam,/no_real)
+  ;Beam uses the forward FFT for the sky->UV transformation (note that the image uses the inverse FFT)
+  psf_base_single=fft_shift(FFT(fft_shift(di_uv_use)))
   psf_base_superres=Interpolate(psf_base_single,xvals_uv_superres,yvals_uv_superres,cubic=-0.5)
   
   s=size(psf_base_superres, /dimensions)


### PR DESCRIPTION
The transformations of the beam between the sky and UV frames use the opposite FFT conventions of the transformations of the data and images. This has the result of flipping the UV-space beam in both dimensions, which gives the correct sign convention when gridding visibilities. If the beam were not flipped in UV space then the apparent sky images would be weighted by the flipped beam, not the true beam. This sign convention was obfuscated in the code. Also, the call to `dirty_image_generate` in `beam_power` was confusing to me. This PR is an attempt to make things somewhat more explicit (although eventually we should probably have a memo explaining all this).