### PR TITLE
Reduce mem

### DIFF
--- a/fhd_core/beam_modeling/beam_power.pro
+++ b/fhd_core/beam_modeling/beam_power.pro
@@ -10,18 +10,22 @@ FUNCTION beam_power,antenna1,antenna2,ant_pol1=ant_pol1,ant_pol2=ant_pol2,freq_i
   icomp = Complex(0, 1)
   freq_center=antenna1.freq[freq_i]
   dimension_super=(size(xvals_uv_superres,/dimension))[0]
+  pix_use=*antenna1[0].pix_use
 
   Jones1=antenna1.Jones[*,*,freq_i]
   Jones2=antenna2.Jones[*,*,freq_i]
 
-  beam_ant1=DComplex(*(antenna1.response[ant_pol1,freq_i]))
-  beam_ant2=DComplex(Conj(*(antenna2.response[ant_pol2,freq_i])))
+  beam_ant1=DComplexarr(psf_image_dim,psf_image_dim)
+  beam_ant2=DComplexarr(psf_image_dim,psf_image_dim)
+  beam_ant1[pix_use]=DComplex(*(antenna1.response[ant_pol1,freq_i]))
+  beam_ant2[pix_use]=DComplex(Conj(*(antenna2.response[ant_pol2,freq_i])))
   beam_norm=1.
   
   ;Amplitude of the response from ant1 is Sqrt(|J1[0,pol1]|^2 + |J1[1,pol1]|^2)
   ;Amplitude of the response from ant2 is Sqrt(|J2[0,pol2]|^2 + |J2[1,pol2]|^2)
   ;Amplitude of the baseline response is the product of the antenna responses
-  power_zenith_beam=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
+  power_zenith_beam=Dcomplexarr(psf_image_dim,psf_image_dim)
+  power_zenith_beam[pix_use]=Sqrt((abs(*Jones1[0,ant_pol1])^2.+abs(*Jones1[1,ant_pol1])^2.)*$
     (abs(*Jones2[0,ant_pol2])^2.+abs(*Jones2[1,ant_pol2])^2.))
   power_zenith=Interpolate(power_zenith_beam,zen_int_x,zen_int_y,cubic=-0.5)
   power_beam = power_zenith_beam*beam_ant1*beam_ant2

--- a/fhd_core/beam_modeling/fhd_struct_init_antenna.pro
+++ b/fhd_core/beam_modeling/fhd_struct_init_antenna.pro
@@ -61,7 +61,8 @@ ENDFOR
 ;initialize antenna structure
 antenna_str={n_pol:n_ant_pol,antenna_type:instrument,names:ant_names,model_version:beam_model_version,freq:freq_center,nfreq_bin:nfreq_bin,$
     n_ant_elements:0,Jones:Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin),coupling:Ptrarr(n_ant_pol,nfreq_bin),gain:Ptrarr(n_ant_pol),coords:Ptrarr(3),$
-    delays:Ptr_new(),size_meters:0.,height:0.,response:Ptrarr(n_ant_pol,nfreq_bin),group_id:Lonarr(n_ant_pol)-1,pix_window:Ptr_new()}
+    delays:Ptr_new(),size_meters:0.,height:0.,response:Ptrarr(n_ant_pol,nfreq_bin),group_id:Lonarr(n_ant_pol)-1,pix_window:Ptr_new(),pix_use:Ptr_new(),$
+    psf_image_dim:0.}
     
 ;update structure with instrument-specific values, and return as a structure array, with an entry for each tile/antenna
 ;first, update to include basic configuration data
@@ -90,6 +91,7 @@ psf_intermediate_res=(Ceil(Sqrt(psf_resolution)/2)*2.)<psf_resolution
 psf_image_dim=psf_dim*psf_image_resolution*psf_intermediate_res ;use a larger box to build the model than will ultimately be used, to allow higher resolution in the initial image space beam model
 psf_superres_dim=psf_dim*psf_resolution
 psf_scale=dimension*psf_intermediate_res/psf_image_dim
+antenna.psf_image_dim=psf_image_dim
 
 xvals_celestial=meshgrid(psf_image_dim,psf_image_dim,1)*psf_scale-psf_image_dim*psf_scale/2.+obsx
 yvals_celestial=meshgrid(psf_image_dim,psf_image_dim,2)*psf_scale-psf_image_dim*psf_scale/2.+obsy
@@ -127,6 +129,9 @@ if keyword_set(kernel_window) then begin
   ;Store image window in antenna structure
   antenna.pix_window=ptr_new(pix_window)
 endif
+
+if ~keyword_set(pix_use) then horizon_test=where(abs(za_arr) GE 90.,n_horizon_test,complement=pix_use,ncomplement=n_pix)
+antenna.pix_use=ptr_new(pix_use)
 
 ;now, update antenna structure to include gains
 if N_elements(instrument) GT 1 then begin

--- a/fhd_core/beam_modeling/general_antenna_response.pro
+++ b/fhd_core/beam_modeling/general_antenna_response.pro
@@ -2,6 +2,7 @@ FUNCTION general_antenna_response,obs,antenna,za_arr=za_arr,az_arr=az_arr,psf_im
 
 n_ant=obs.n_tile
 n_ant_pol=antenna[0].n_pol ;this needs to be the same for all antennas!
+pix_use=*antenna[0].pix_use
 icomp=Complex(0,1)
 c_light_vacuum=299792458.
 
@@ -41,7 +42,7 @@ FOR pol_i=0,n_ant_pol-1 DO BEGIN
         
         response_grp=Ptrarr(nfreq_bin)
         FOR freq_i=0L,nfreq_bin-1 DO BEGIN
-            response=Complexarr(psf_image_dim,psf_image_dim)
+            response=Complexarr(N_elements(pix_use))
             Kconv=(2.*!Pi)*(freq_center[freq_i]/c_light_vacuum) 
             antenna_gain_arr=Exp(-icomp*Kconv*D_d)
             voltage_delay=Exp(icomp*2.*!Pi*delays*(freq_center[freq_i])*Reform((*gain[pol_i])[freq_i,*])) 
@@ -50,7 +51,7 @@ FOR pol_i=0,n_ant_pol-1 DO BEGIN
             meas_current/=zenith_norm
 
             FOR ii=0L,n_ant_elements-1 DO BEGIN
-                response+=antenna_gain_arr[*,*,ii]*meas_current[ii]/n_ant_elements
+                response+=(antenna_gain_arr[*,*,ii]*meas_current[ii]/n_ant_elements)[pix_use]
             ENDFOR
             response_grp[freq_i]=Ptr_new(response)
         ENDFOR

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -13,13 +13,8 @@ beam_struct={beam,xx:0.,yy:0.,xy:Complex(0.),yx:Complex(0.),I:0.,Q:0.,U:0.,V:0.}
 shape_struct={x:0.,y:0.,angle:0.} ;gets used if keyword gaussian_source_models is set
 ;flux order is 0-3: xx, yy, xy, yx in apparent brightness; 4-7: I, Q, U, V in sky brightness
 ;flag type codes are 0: no flag, 1: low confidence 2: sidelobe contamination
-IF keyword_set(shape) THEN BEGIN
-    struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
-        flux:flux_struct,shape:shape_struct,beam:beam_struct}
-ENDIF ELSE BEGIN
-    struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
-        flux:flux_struct,beam:beam_struct}
-ENDELSE
+struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
+    flux:flux_struct,shape:shape_struct,beam:beam_struct}
 source_comp_new=Replicate(struct_base,n_sources>1)
 
 IF Keyword_Set(xvals) THEN source_comp_new.x=xvals

--- a/fhd_core/deconvolution/source_detection/source_comp_init.pro
+++ b/fhd_core/deconvolution/source_detection/source_comp_init.pro
@@ -13,8 +13,13 @@ beam_struct={beam,xx:0.,yy:0.,xy:Complex(0.),yx:Complex(0.),I:0.,Q:0.,U:0.,V:0.}
 shape_struct={x:0.,y:0.,angle:0.} ;gets used if keyword gaussian_source_models is set
 ;flux order is 0-3: xx, yy, xy, yx in apparent brightness; 4-7: I, Q, U, V in sky brightness
 ;flag type codes are 0: no flag, 1: low confidence 2: sidelobe contamination
-struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
-    flux:flux_struct,shape:shape_struct,beam:beam_struct}
+IF keyword_set(shape) THEN BEGIN
+    struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
+        flux:flux_struct,shape:shape_struct,beam:beam_struct}
+ENDIF ELSE BEGIN
+    struct_base={id:-1L,x:0.,y:0.,ra:0.,dec:0.,ston:0.,freq:100.,alpha:0.,gain:1.,flag:0,extend:Ptr_new(),$
+        flux:flux_struct,beam:beam_struct}
+ENDELSE
 source_comp_new=Replicate(struct_base,n_sources>1)
 
 IF Keyword_Set(xvals) THEN source_comp_new.x=xvals

--- a/fhd_core/polarization/fhd_struct_init_jones.pro
+++ b/fhd_core/polarization/fhd_struct_init_jones.pro
@@ -53,7 +53,7 @@ apply_astrometry, obs, dec_arr=lat, x_arr=x_t, y_arr=y_t, /xy2ad, /ignore_refrac
 obs_temp = fhd_struct_update_obs(obs, beam_nfreq_avg=obs.n_freq) ; Use only one average Jones matrix, not one per frequency
 antenna=fhd_struct_init_antenna(obs_temp,beam_model_version=beam_model_version,psf_resolution=1.,$
     psf_dim=obs.dimension,psf_intermediate_res=1.,psf_image_resolution=1.,timing=t_ant)
-Jones=rotate_jones_matrix(obs, antenna[0].Jones[*,*,0])
+Jones=rotate_jones_matrix(obs, antenna[0])
 
 ; Calculate the normalization
 ant_pol1 = 0

--- a/fhd_core/polarization/rotate_jones_matrix.pro
+++ b/fhd_core/polarization/rotate_jones_matrix.pro
@@ -1,5 +1,16 @@
-FUNCTION rotate_jones_matrix, obs, Jones, in_place=in_place
+FUNCTION rotate_jones_matrix, obs, antenna, in_place=in_place
 ;Rotate the 2x2 Jones matix from Az-ZA coordinates to RA-Dec, using the parallactic angle
+
+;Formulate Jones matrix from antenna structure
+Jones = PTRARR(antenna.n_pol,antenna.n_pol)
+pix_use = *antenna.pix_use
+psf_image_dim = antenna.psf_image_dim
+for pol_i = 0, antenna.n_pol-1 do begin
+    for pol_j=0, antenna.n_pol-1 do begin
+        Jones[pol_i,pol_j] = Ptr_new(DComplexarr(psf_image_dim,psf_image_dim))
+        (*Jones[pol_i,pol_j])[pix_use] = (*antenna.Jones[pol_i,pol_j])
+    endfor
+endfor
 
 ;Generate a grid of RA and Dec coordinates matching the image
 xvals=meshgrid(obs.dimension,obs.elements,1)

--- a/fhd_core/source_modeling/source_dft_multi.pro
+++ b/fhd_core/source_modeling/source_dft_multi.pro
@@ -88,7 +88,7 @@ IF keyword_set(gaussian_source_models) then begin
         [source_array.ra-.5*gaussian_ra_angular*cos(gaussian_rot)], [source_array.ra+.5*gaussian_dec*sin(gaussian_rot)]]
       gaussian_dec_vals = [[source_array.dec+.5*gaussian_ra_angular*sin(gaussian_rot)], [source_array.dec+.5*gaussian_dec*cos(gaussian_rot)], $
         [source_array.dec-.5*gaussian_ra_angular*sin(gaussian_rot)], [source_array.dec-.5*gaussian_dec*cos(gaussian_rot)]]
-      undefine, gaussian_ra, gaussian_ra_angular, gaussian_dec, gaussian_rot
+      undefine, gaussian_ra, gaussian_ra_angular, gaussian_dec
 
       ;Curved sky gaussian widths in pixel coords
       apply_astrometry, obs, x_arr=gaussian_x_vals, y_arr=gaussian_y_vals, ra_arr=gaussian_ra_vals, dec_arr=gaussian_dec_vals, /ad2xy
@@ -134,14 +134,14 @@ IF Keyword_Set(n_spectral) THEN BEGIN
                 n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         endif else begin
             edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
-                gaussian_ra,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+                gaussian_x,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         endelse
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
                 conserve_memory=conserve_memory,silent=silent,inds_use=edge_i,double_precision=double_precision,$
-                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x, gaussian_y=gaussian_y, $
-                gaussian_rot=gaussian_rot)
+                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x[edge_i], gaussian_y=gaussian_y[edge_i], $
+                gaussian_rot=gaussian_rot[edge_i])
             FOR pol_i=0,n_pol-1 DO BEGIN
                 FOR s_i=0L,n_spectral DO BEGIN ;no "-1" for second loop!
                     single_uv=Complexarr(dimension,elements)
@@ -206,14 +206,14 @@ ENDIF ELSE BEGIN
                 n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         endif else begin
             edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
-                gaussian_ra,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+                gaussian_x,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         endelse
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
                 conserve_memory=conserve_memory,silent=silent,inds_use=edge_i,double_precision=double_precision,$
-                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x, gaussian_y=gaussian_y, $
-                gaussian_rot=gaussian_rot)
+                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x[edge_i], gaussian_y=gaussian_y[edge_i], $
+                gaussian_rot=gaussian_rot[edge_i])
             FOR pol_i=0,n_pol-1 DO BEGIN
                 single_uv=Complexarr(dimension,elements)
                 single_uv[uv_i_use]=*model_uv_vals[pol_i] 

--- a/fhd_core/source_modeling/source_dft_multi.pro
+++ b/fhd_core/source_modeling/source_dft_multi.pro
@@ -129,8 +129,13 @@ IF Keyword_Set(n_spectral) THEN BEGIN
     
     IF Keyword_Set(dft_threshold) THEN BEGIN
         model_uv_arr=Ptrarr(n_pol,n_spectral+1)
-        edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix),$
-            n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        if ~keyword_set(gaussian_source_models) then begin
+            edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix),$
+                n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        endif else begin
+            edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
+                gaussian_ra,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        endelse
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
@@ -155,8 +160,8 @@ IF Keyword_Set(n_spectral) THEN BEGIN
             Ptr_free,model_uv_arr2
         ENDIF
         IF not Keyword_Set(silent) THEN BEGIN
-            print,"Center sources using DFT approximation: " + Strn(n_center_pix)
-            print,"Edge sources using true DFT: " + Strn(n_edge_pix)
+            print,"Center source components using DFT approximation: " + Strn(n_center_pix)
+            print,"Edge source components or gaussian components using true DFT: " + Strn(n_edge_pix)
         ENDIF
         Ptr_free,flux_arr
     ENDIF ELSE BEGIN
@@ -196,8 +201,13 @@ ENDIF ELSE BEGIN
     ENDIF
     IF Keyword_Set(dft_threshold) THEN BEGIN
         model_uv_arr=Ptrarr(n_pol)
-        edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix),$
-            n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        if ~keyword_set(gaussian_source_models) then begin
+            edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix),$
+                n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        endif else begin
+            edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
+                gaussian_ra,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+        endelse
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
@@ -221,8 +231,8 @@ ENDIF ELSE BEGIN
         ENDIF
         FOR pol_i=0,n_pol-1 DO *model_uv_full[pol_i]+=*model_uv_arr[pol_i]
         IF not Keyword_Set(silent) THEN BEGIN
-            print,"Center sources using DFT approximation: " + Strn(n_center_pix)
-            print,"Edge sources using true DFT: " + Strn(n_edge_pix)
+            print,"Center source components using DFT approximation: " + Strn(n_center_pix)
+            print,"Edge source components or gaussian components using true DFT: " + Strn(n_edge_pix)
         ENDIF
         undefine_fhd,model_uv_arr,flux_arr
     ENDIF ELSE BEGIN

--- a/fhd_utils/FFT/source_dft.pro
+++ b/fhd_utils/FFT/source_dft.pro
@@ -139,10 +139,6 @@ IF size(flux_use,/type) EQ 10 THEN BEGIN ;check if pointer type. This allows the
       *source_uv_vals[fbin_use[fbin_i]]=Complex(Temporary(*source_uv_vals[fbin_use[fbin_i]]))
   ENDIF ELSE BEGIN
     IF Keyword_Set(conserve_memory) AND (element_check GT mem_thresh) THEN BEGIN
-        if keyword_set(gaussian_source_models) then begin
-          print, 'Gaussian source modeling is not compatible with keyword conserve_memory at this time. Unsetting keyword gaussian_source_models.'
-          undefine, gaussian_source_models
-        endif
         memory_bins=Round(element_check/mem_thresh)
         source_uv_vals=DComplexarr(size(xvals,/dimension))
         n0=N_Elements(x_use)

--- a/instrument_config/hera_beam_setup_gain.pro
+++ b/instrument_config/hera_beam_setup_gain.pro
@@ -73,7 +73,7 @@ CASE beam_model_version OF
                   + Complex(0,1) * healpix_interpolate(imaginary(hera_beam_interp[beam_pix[*,beam_i],freq_i]),obs,nside=nside,Jdate_use=Jdate_use,coord_sys='equatorial') 
                 ;Create the Jones matrix
                 ;Note: Elements of Jones matrix may not be in the proper basis to be used individually due to the 90deg rotation, though this will not affect the power beam
-                Jones_matrix[matrix_inds[0,beam_i],matrix_inds[1,beam_i],freq_i]=Ptr_new(Interpolate(hera_beam_grid_arr,xvals_interp,yvals_interp)*horizon_mask)
+                Jones_matrix[matrix_inds[0,beam_i],matrix_inds[1,beam_i],freq_i]=Ptr_new((Interpolate(hera_beam_grid_arr,xvals_interp,yvals_interp)*horizon_mask)[pix_use])
             
             endfor
           
@@ -102,8 +102,8 @@ CASE beam_model_version OF
             hera_beam_interp_arr=Ptrarr(nfreq_bin)
             FOR freq_i=0,nfreq_bin-1 DO hera_beam_interp_arr[freq_i]=Ptr_new(hera_beam_interp[*,freq_i])
             hera_beam_grid_arr=healpix_interpolate(hera_beam_interp_arr,obs,nside=nside,Jdate_use=Jdate_use,coord_sys='equatorial')
-            FOR freq_i=0,nfreq_bin-1 DO Jones_matrix[pol_i,pol_i,freq_i]=Ptr_new(Interpolate(*hera_beam_grid_arr[freq_i],xvals_interp,yvals_interp)*horizon_mask)
-            FOR freq_i=0,nfreq_bin-1 DO Jones_matrix[pol_i,(pol_i+1) mod 2,freq_i]=Ptr_new(Fltarr(psf_image_dim,psf_image_dim))
+            FOR freq_i=0,nfreq_bin-1 DO Jones_matrix[pol_i,pol_i,freq_i]=Ptr_new((Interpolate(*hera_beam_grid_arr[freq_i],xvals_interp,yvals_interp)*horizon_mask)[pix_use])
+            FOR freq_i=0,nfreq_bin-1 DO Jones_matrix[pol_i,(pol_i+1) mod 2,freq_i]=Ptr_new(Fltarr(n_pix))
         ENDFOR
     ENDELSE
 

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -9,6 +9,7 @@ n_tile=obs.n_tile
 beam_model_version=Max(antenna.model_version)
 xvals_instrument=za_arr*Sin(az_arr*!DtoR)
 yvals_instrument=za_arr*Cos(az_arr*!DtoR)
+horizon_test=where(abs(za_arr) GE 90.,n_horizon_test,complement=pix_use,ncomplement=n_pix)
 freq_center=antenna[0].freq ;all need to be identical, so just use the first
 speed_light=299792458. ;speed of light, in meters/second
 icomp=Complex(0,1)
@@ -86,7 +87,6 @@ CASE beam_model_version OF
 ;        IF n_zenith GT 0 THEN $
 ;            FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO (*Jmat_interp[p_i,p_j,freq_i])[zenith_i]=Sqrt(Mean(Abs((*Jmat_interp[p_i,p_j,freq_i])[zenith_i])^2.))
         
-        horizon_test=where(abs(za_arr) GE 90.,n_horizon_test,complement=pix_use,ncomplement=n_pix)
         horizon_mask=fltarr(psf_image_dim,psf_image_dim)+1
         IF n_horizon_test GT 0 THEN horizon_mask[horizon_test]=0  
         Jones_matrix=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
@@ -157,10 +157,10 @@ CASE beam_model_version OF
             groundplane=2.*Sin(Cos(za_arr*!DtoR)*(2.*!Pi*(antenna_height)/wavelength[freq_i])) ;should technically have zc_arr, but until that is nonzero this is the same and faster
             groundplane0=2.*Sin(Cos(0.*!DtoR)*2.*!Pi*antenna_height/wavelength[freq_i]) ;normalization factor
             groundplane/=groundplane0
-            Jones_matrix[0,0,freq_i]=Ptr_new(Sqrt(1.-(Sin(za_arr*!DtoR)*Sin(az_arr*!DtoR))^2.)*groundplane)
-            Jones_matrix[1,0,freq_i]=Ptr_new(0.*groundplane)
-            Jones_matrix[0,1,freq_i]=Ptr_new(0.*groundplane)
-            Jones_matrix[1,1,freq_i]=Ptr_new(Sqrt(1.-(Sin(za_arr*!DtoR)*Cos(az_arr*!DtoR))^2.)*groundplane)
+            Jones_matrix[0,0,freq_i]=Ptr_new((Sqrt(1.-(Sin(za_arr*!DtoR)*Sin(az_arr*!DtoR))^2.)*groundplane)[pix_use])
+            Jones_matrix[1,0,freq_i]=Ptr_new((0.*groundplane)[pix_use])
+            Jones_matrix[0,1,freq_i]=Ptr_new((0.*groundplane)[pix_use])
+            Jones_matrix[1,1,freq_i]=Ptr_new((Sqrt(1.-(Sin(za_arr*!DtoR)*Cos(az_arr*!DtoR))^2.)*groundplane)[pix_use])
         ENDFOR
     
     END
@@ -173,10 +173,10 @@ CASE beam_model_version OF
             groundplane=2.*Sin(Cos(za_arr*!DtoR)*(2.*!Pi*(antenna_height)/wavelength[freq_i])) ;should technically have zc_arr, but until that is nonzero this is the same and faster
             groundplane0=2.*Sin(Cos(0.*!DtoR)*2.*!Pi*antenna_height/wavelength[freq_i]) ;normalization factor
             groundplane/=groundplane0
-            Jones_matrix[0,0,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Sin(az_arr*!DtoR)*groundplane)
-            Jones_matrix[1,0,freq_i]=Ptr_new(Cos(az_arr*!DtoR)*groundplane)
-            Jones_matrix[0,1,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Cos(az_arr*!DtoR)*groundplane)
-            Jones_matrix[1,1,freq_i]=Ptr_new(-Sin(az_arr*!DtoR)*groundplane)
+            Jones_matrix[0,0,freq_i]=Ptr_new((Cos(za_arr*!DtoR)*Sin(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[1,0,freq_i]=Ptr_new((Cos(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[0,1,freq_i]=Ptr_new((Cos(za_arr*!DtoR)*Cos(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[1,1,freq_i]=Ptr_new((-Sin(az_arr*!DtoR)*groundplane)[pix_use])
         ENDFOR
     ENDELSE
 ENDCASE

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -91,7 +91,7 @@ CASE beam_model_version OF
         IF n_horizon_test GT 0 THEN horizon_mask[horizon_test]=0  
         Jones_matrix=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO $
-            Jones_matrix[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(psf_image_dim,psf_image_dim))
+            Jones_matrix[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(n_pix))
             
         interp_res=obs.degpix
         angle_slice_i0=Uniq(phi_arr)
@@ -113,7 +113,7 @@ CASE beam_model_version OF
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO BEGIN
             Jmat_use=Reform(*Jmat_interp[p_i,p_j,freq_i],n_zen_slice,n_ang_slice)
             Expand,Jmat_use,n_zen_ang,n_az_ang,Jmat_single
-            (*Jones_matrix[p_i,p_j,freq_i])[pix_use]=Interpolate(Jmat_single,zen_ang_inst/interp_res,az_ang_inst/interp_res,cubic=-0.5)
+            (*Jones_matrix[p_i,p_j,freq_i])=Interpolate(Jmat_single,zen_ang_inst/interp_res,az_ang_inst/interp_res,cubic=-0.5)
             debug_point=1
         ENDFOR
         debug_point=1
@@ -186,7 +186,6 @@ ENDCASE
 ;    zenith_norm[pol_i,freq_i]=Sqrt(Max(abs((*Jones_matrix[0,pol_i,freq_i])*(Conj(*Jones_matrix[0,pol_i,freq_i]))+$
 ;         (*Jones_matrix[1,pol_i,freq_i])*(Conj(*Jones_matrix[1,pol_i,freq_i])))))
 antenna.jones=Jones_matrix
-
 
 RETURN,antenna
 END

--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -87,8 +87,6 @@ CASE beam_model_version OF
 ;        IF n_zenith GT 0 THEN $
 ;            FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO (*Jmat_interp[p_i,p_j,freq_i])[zenith_i]=Sqrt(Mean(Abs((*Jmat_interp[p_i,p_j,freq_i])[zenith_i])^2.))
         
-        horizon_mask=fltarr(psf_image_dim,psf_image_dim)+1
-        IF n_horizon_test GT 0 THEN horizon_mask[horizon_test]=0  
         Jones_matrix=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO $
             Jones_matrix[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(n_pix))

--- a/instrument_config/paper_beam_setup_gain.pro
+++ b/instrument_config/paper_beam_setup_gain.pro
@@ -8,6 +8,7 @@ n_tile=obs.n_tile
 beam_model_version=Max(antenna.model_version)
 xvals_instrument=za_arr*Sin(az_arr*!DtoR)
 yvals_instrument=za_arr*Cos(az_arr*!DtoR)
+pix_use=*antenna[0].pix_use
 freq_center=antenna[0].freq ;all need to be identical, so just use the first
 speed_light=299792458. ;speed of light, in meters/second
 icomp=Complex(0,1)
@@ -72,9 +73,9 @@ CASE beam_model_version OF
                 freq_i_test=Min(abs(freq_arr-freq_center[freq_i]),freq_i_use)
                 beam_slice=Reform(beam_cube[*,*,freq_i_use])
                 tile_beam=Float(interpolate(beam_slice,x_int,y_int,missing=0,cubic=-0.5))>0.
-                Jones_matrix[pol_i,pol_i,freq_i]=Ptr_new(tile_beam)
+                Jones_matrix[pol_i,pol_i,freq_i]=Ptr_new((tile_beam)[pix_use])
                 xpol_i=Abs(1-pol_i)
-                Jones_matrix[xpol_i,pol_i,freq_i]=Ptr_new(Fltarr(size(tile_beam,/dimension))) ;all zeroes
+                Jones_matrix[xpol_i,pol_i,freq_i]=Ptr_new(Fltarr(N_elements(pix_use))) ;all zeroes
             ENDFOR
         ENDFOR
     END
@@ -87,14 +88,10 @@ CASE beam_model_version OF
             groundplane=2.*Sin(Cos(za_arr*!DtoR)*(2.*!Pi*(antenna_height)/wavelength[freq_i])) ;should technically have zc_arr, but until that is nonzero this is the same and faster
             groundplane0=2.*Sin(Cos(0.*!DtoR)*2.*!Pi*antenna_height/wavelength[freq_i]) ;normalization factor
             groundplane/=groundplane0
-            Jones_matrix[0,0,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Sin(az_arr*!DtoR)*groundplane)
-            Jones_matrix[1,0,freq_i]=Ptr_new(Cos(az_arr*!DtoR)*groundplane)
-            Jones_matrix[0,1,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Cos(az_arr*!DtoR)*groundplane)
-            Jones_matrix[1,1,freq_i]=Ptr_new(-Sin(az_arr*!DtoR)*groundplane)
-;            Jones_matrix[0,0,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Cos(az_arr*!DtoR)*groundplane)
-;            Jones_matrix[1,0,freq_i]=Ptr_new(Sin(az_arr*!DtoR)*groundplane)
-;            Jones_matrix[0,1,freq_i]=Ptr_new(Cos(za_arr*!DtoR)*Sin(az_arr*!DtoR)*groundplane)
-;            Jones_matrix[1,1,freq_i]=Ptr_new(-Cos(az_arr*!DtoR)*groundplane)
+            Jones_matrix[0,0,freq_i]=Ptr_new((Cos(za_arr*!DtoR)*Sin(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[1,0,freq_i]=Ptr_new((Cos(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[0,1,freq_i]=Ptr_new((Cos(za_arr*!DtoR)*Cos(az_arr*!DtoR)*groundplane)[pix_use])
+            Jones_matrix[1,1,freq_i]=Ptr_new((-Sin(az_arr*!DtoR)*groundplane)[pix_use])
         ENDFOR
     ENDELSE
 ENDCASE


### PR DESCRIPTION
To reduce memory load, only store values of the zero-padded beam image which are not zero. Subsequently, store their array index so that zero-padded beam images can be made on the fly during degridding/gridding.

This reduces the memory load significantly, up to 50% when 384 freq-dependent beams are used.

One additional commit: force the gaussian source models to use the true dft versus the dft approximation. @isullivan, can you confirm whether or not the gaussian source models can use the dft approximation? The gaussian source models are made be multiplying a point source uv-plane with a gaussian envelope, a la [Line et al. 2020](https://arxiv.org/abs/2005.09316) Eq 11. 