### PR TITLE
simple hotfixes

### DIFF
--- a/fhd_core/setup_metadata/fhd_setup.pro
+++ b/fhd_core/setup_metadata/fhd_setup.pro
@@ -31,8 +31,12 @@ IF N_Elements(flag_visibilities) EQ 0 THEN flag_visibilities=0
 IF N_Elements(transfer_mapfn) EQ 0 THEN transfer_mapfn=0
 IF N_Elements(save_visibilities) EQ 0 THEN save_visibilities=1
 IF N_Elements(healpix_recalculate) EQ 0 THEN healpix_recalculate=recalculate_all
-IF N_Elements(beam_recalculate) EQ 0 THEN IF status_str.psf EQ 0 THEN beam_recalculate=1 $
-    ELSE beam_recalculate=recalculate_all
+IF N_Elements(beam_recalculate) EQ 0 THEN beam_recalculate=recalculate_all
+IF Keyword_Set(beam_recalculate) THEN BEGIN
+    status_str.psf=0
+    status_str.antenna=0
+    status_str.jones=0
+ENDIF
 
 IF Keyword_Set(n_pol) THEN n_pol1=n_pol ELSE BEGIN
     IF status_str.obs GT 0 THEN BEGIN

--- a/fhd_core/setup_metadata/fhd_struct_update_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_update_obs.pro
@@ -70,12 +70,7 @@ struct.code_version=String(code_version)
 
 
 b_info=*obs.baseline_info
-;freq_use:Fix(freq_use)
-;tile_use:Fix(tile_use)
-;time_use:Fix(time_use)
-;tile_flag:meta.tile_flag
 b_info.fbin_i=Long(freq_bin_i)
-b_info.freq=Float(frequency_array)
 struct.baseline_info=Ptr_new(b_info)
 
 RETURN,struct


### PR DESCRIPTION
1) The beam recalculate option I put in previously did not always get used because of a resetting of the status string that I hadn't noticed. I moved the logic earlier so that it takes precedence. Tested, works.

2) During the making of healpix cubes, the obs structure is updated and stored with the cubes. The frequency array is recast to floats during the process. I removed the recast so that the frequencies are as accurate as possible (important for eppsilon frequency dft-ing). Tested, works.