### PR TITLE
Correctly handle nans in cal flagging and transfer flags

### DIFF
--- a/fhd_core/calibration/vis_calibration_flag.pro
+++ b/fhd_core/calibration/vis_calibration_flag.pro
@@ -29,16 +29,20 @@ FOR pol_i=0,n_pol-1 DO BEGIN
     amp_sub=extract_subarray(amp,freq_use_i0,tile_use_i0)
     gain_freq_test=Median(amp_sub,dimension=2)
     gain_freq_fom=fltarr(n_freq_use) 
-    FOR freq_i=0,n_freq_use-1 DO gain_freq_fom[freq_i]=Stddev(amp_sub[freq_i,*])
+    FOR freq_i=0,n_freq_use-1 DO gain_freq_fom[freq_i]=Stddev(amp_sub[freq_i,*],/nan)
     gain_tile_fom=fltarr(n_tile_use)
     gain_tile_avg=fltarr(n_tile_use) 
     FOR tile_i=0,n_tile_use-1 DO BEGIN
         amp_sub2=amp_sub[*,tile_i]
         fit_params=poly_fit(freq_use_i0,amp_sub2,amp_degree,yfit=amp_sub2_fit)
-        gain_tile_fom[tile_i]=Stddev(amp_sub2-amp_sub2_fit)
+        gain_tile_fom[tile_i]=Stddev(amp_sub2-amp_sub2_fit,/nan)
         gain_tile_avg[tile_i]=Median(amp_sub2)
     ENDFOR
     
+    nan_i=where(~finite(gain_freq_fom),n_nan)
+    if n_nan GT 0 THEN gain_freq_fom[nan_i]=0
+    nan_i=where(~finite(gain_tile_fom),n_nan)
+    if n_nan GT 0 THEN gain_tile_fom[nan_i]=0
     freq_cut_i=where(gain_freq_fom EQ 0,n_freq_cut,ncomp=n_freq_uncut,complement=freq_uncut_i)
     tile_cut_i=where(gain_tile_fom EQ 0,n_tile_cut,ncomp=n_tile_uncut,complement=tile_uncut_i)
     IF n_freq_cut GT 0 THEN freq_use[freq_use_i0[freq_cut_i]]=0
@@ -52,8 +56,8 @@ FOR pol_i=0,n_pol-1 DO BEGIN
     n_cut=n_freq_cut+n_tile_cut
     iter=0
     WHILE n_addl_cut GT 0 DO BEGIN
-        gain_freq_sigma=Stddev(gain_freq_fom[freq_uncut_i])
-        gain_tile_sigma=Stddev(gain_tile_fom[tile_uncut_i])
+        gain_freq_sigma=Stddev(gain_freq_fom[freq_uncut_i],/nan)
+        gain_tile_sigma=Stddev(gain_tile_fom[tile_uncut_i],/nan)
         freq_cut_test=(gain_freq_fom-Median(gain_freq_fom[freq_uncut_i])-amp_sigma_threshold*gain_freq_sigma) GT 0
         freq_cut_i=where(freq_cut_test,n_freq_cut,ncomp=n_freq_uncut,complement=freq_uncut_i)
         tile_cut_test1=(gain_tile_fom-Median(gain_tile_fom[tile_uncut_i])-amp_sigma_threshold*gain_tile_sigma) GT 0
@@ -82,7 +86,7 @@ FOR pol_i=0,n_pol-1 DO BEGIN
 ;        FOR iter=0,2 DO BEGIN
             phase_use2=phase_use[fi_use2]-phase_fit
             phase_params=poly_fit(freq_use_i1[fi_use2],phase_use2,phase_degree,yfit=phase_fit)
-            phase_sigma2=Stddev(phase_use2-phase_fit)
+            phase_sigma2=Stddev(phase_use2-phase_fit,/nan)
             fi_use2_i=where(Abs(phase_use2-phase_fit) LT 3.*phase_sigma2,n_fi2)
 ;            IF n_fi2 LE 2 THEN BREAK
 ;            fi_use2=fi_use2[fi_use2_i]
@@ -95,9 +99,9 @@ FOR pol_i=0,n_pol-1 DO BEGIN
     n_addl_cut=1
     n_cut=0
     WHILE n_addl_cut GT 0 DO BEGIN
-        slope_sigma=Stddev(phase_slope_arr)
+        slope_sigma=Stddev(phase_slope_arr,/nan)
         tile_cut_test1=(Abs(phase_slope_arr)-Median(Abs(phase_slope_arr))) GT phase_sigma_threshold*slope_sigma
-        tile_cut_test2=(phase_sigma_arr-Median(phase_sigma_arr)) GT phase_sigma_threshold*Stddev(phase_sigma_arr)
+        tile_cut_test2=(phase_sigma_arr-Median(phase_sigma_arr)) GT phase_sigma_threshold*Stddev(phase_sigma_arr,/nan)
         tile_cut_i=where(tile_cut_test1 OR tile_cut_test2,n_tile_cut,ncomp=n_tile_uncut,complement=tile_uncut_i)
         n_addl_cut=(n_tile_cut)-n_cut
         n_cut=n_tile_cut


### PR DESCRIPTION
NaN's weren't being correctly handled during calibration flagging (particularly in calculating standard deviations). This doesn't actually affect the calibration solutions and calibrated visibilities (applying a NaN calibration effectively flags that visibility anyways) but it *does* affect the metadata and associated counting statistics.

In addition, zeroed or NaN'd calibration solutions were not being translated into flagged tiles/frequencies when calibration solutions were transferred. I've found where the flagged frequencies and tiles were in the calibration solutions, and then broadcasted them across pols. Is that the general behaviour that we want?