### PR TITLE
Fragile beam recalculation keyword needs to go

### DIFF
--- a/fhd_core/fhd_main.pro
+++ b/fhd_core/fhd_main.pro
@@ -73,16 +73,11 @@ IF data_flag LE 0 THEN BEGIN
     fhd_save_io,status_str,obs,var='obs',/compress,file_path_fhd=file_path_fhd,_Extra=extra ;save obs structure right away for debugging. Will be overwritten a few times before the end
     IF Keyword_Set(deproject_w_term) THEN vis_arr=simple_deproject_w_term(obs,params,vis_arr,direction=deproject_w_term)
     
-    ;Read in or construct a new beam model. Also sets up the structure PSF
-    IF keyword_set(beam_recalculate) THEN BEGIN
-        print,'Calculating beam model'
-        psf=beam_setup(obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_last=0,silent=silent,timing=t_beam,no_save=no_save,_Extra=extra)
-        IF Keyword_Set(t_beam) THEN IF ~Keyword_Set(silent) THEN print,'Beam modeling time: ',t_beam
-        jones=fhd_struct_init_jones(obs,status_str,file_path_fhd=file_path_fhd,restore=0,mask=beam_mask,_Extra=extra)
-    ENDIF ELSE BEGIN
-        fhd_save_io,status_str,psf,file_path_fhd=file_path_fhd,var_name='psf',/restore
-        fhd_save_io,status_str,jones,file_path_fhd=file_path_fhd,var_name='jones',/restore
-    ENDELSE
+    ;Construct a new beam model. Also sets up the structure PSF
+    print,'Calculating beam model'
+    psf=beam_setup(obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_last=0,silent=silent,timing=t_beam,no_save=no_save,_Extra=extra)
+    IF Keyword_Set(t_beam) THEN IF ~Keyword_Set(silent) THEN print,'Beam modeling time: ',t_beam
+    jones=fhd_struct_init_jones(obs,status_str,file_path_fhd=file_path_fhd,restore=0,mask=beam_mask,_Extra=extra)
 
     IF Keyword_Set(transfer_weights) THEN BEGIN
         flag_visibilities=0 ;

--- a/fhd_core/setup_metadata/fhd_setup.pro
+++ b/fhd_core/setup_metadata/fhd_setup.pro
@@ -31,12 +31,6 @@ IF N_Elements(flag_visibilities) EQ 0 THEN flag_visibilities=0
 IF N_Elements(transfer_mapfn) EQ 0 THEN transfer_mapfn=0
 IF N_Elements(save_visibilities) EQ 0 THEN save_visibilities=1
 IF N_Elements(healpix_recalculate) EQ 0 THEN healpix_recalculate=recalculate_all
-IF N_Elements(beam_recalculate) EQ 0 THEN beam_recalculate=recalculate_all
-IF Keyword_Set(beam_recalculate) THEN BEGIN
-    status_str.psf=0
-    status_str.antenna=0
-    status_str.jones=0
-ENDIF
 
 IF Keyword_Set(n_pol) THEN n_pol1=n_pol ELSE BEGIN
     IF status_str.obs GT 0 THEN BEGIN
@@ -79,11 +73,6 @@ ENDIF ELSE IF N_Elements(mapfn_recalculate) EQ 0 THEN mapfn_recalculate=0
 IF mapfn_recalculate GT 0 THEN grid_recalculate=1
 IF grid_recalculate GT 0 THEN data_flag=0
 
-IF Keyword_Set(beam_recalculate) THEN BEGIN
-    status_str.psf=0
-    status_str.antenna=0
-    status_str.jones=0
-ENDIF
 status_str.hpx_cnv=0
 IF Keyword_Set(mapfn_recalculate) THEN grid_recalculate=1
 IF Keyword_Set(grid_recalculate) THEN BEGIN


### PR DESCRIPTION
The beam recalculation logic is too fragile, and needs to be extracted from the main branch for now.

Some recent requests have indicated that a rethink of some other recalculation keywords would be handy, so we should pick this back up in another branch in the future.