### PR TITLE
Fix a bug preventing fitting reflections on multiple cables, improve convergence print statement

### DIFF
--- a/fhd_core/calibration/vis_cal_polyfit.pro
+++ b/fhd_core/calibration/vis_cal_polyfit.pro
@@ -5,10 +5,10 @@ FUNCTION vis_cal_polyfit,cal,obs,cal_step_fit=cal_step_fit,cal_neighbor_freq_fla
     
   IF Keyword_Set(cal_reflection_mode_theory) OR Keyword_Set(cal_reflection_mode_file) $
     OR Keyword_Set(cal_reflection_mode_delay) OR Keyword_Set(cal_reflection_hyperresolve) THEN BEGIN
-    IF (cal.mode_fit EQ 0) THEN cal.mode_fit=1.
+    IF not Keyword_Set(cal.mode_fit) THEN cal.mode_fit=1.
   ENDIF
   cal_mode_fit=cal.mode_fit
-  IF (cal_mode_fit EQ 1) AND keyword_set(cal_reflection_mode_theory) then $
+  IF Keyword_Set(cal_mode_fit) AND keyword_set(cal_reflection_mode_theory) then $
     if (abs(cal_reflection_mode_theory) GT 1) then cal_mode_fit = cal_reflection_mode_theory
   IF Tag_exist(cal,"amp_degree") THEN amp_degree = cal.amp_degree ELSE amp_degree=2
   IF Tag_exist(cal,"phase_degree") THEN phase_degree = cal.phase_degree ELSE phase_degree=1

--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -197,7 +197,8 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
             ENDIF
         ENDFOR
         IF i EQ max_cal_iter THEN BEGIN
-            print,String(format='("Calibration reached max iterations before converging for pol_i: ", A, " freq_i: ",A)', Strn(pol_i), Strn(fi)) 
+            print, String(format='("Calibration reached max iterations before converging for pol_i: ", A, " freq_i: ", A,". Convergence was: ", A, " threshold was: ", A)', $
+                          Strn(pol_i), Strn(fi), Strn(conv_test[fii,i-1], format="(e12.2)"), Strn(conv_thresh, format="(e12.2)")) 
         ENDIF
         convergence[fi,tile_use]=Abs(gain_curr-gain_old)*weight_invert(Abs(gain_old))
         Ptr_free,A_ind_arr


### PR DESCRIPTION
Due to a bug, setting `cal_mode_fit` to an array of multiple cable lengths caused an error. This PR fixes that bug.

It also improves the printed message when a freq, pol doesn't converge in calibration to include the amount the convergence was off by and the convergence tolerance so the user can tell how off they were.