### PR TITLE
Three rare or minor gridding effects

### DIFF
--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -102,7 +102,7 @@ dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
-range_test_x_i=where(((xmin+(psf_dim/2-1)) LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+range_test_x_i=where(((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
 range_test_y_i=where(((ymin+(psf_dim/2-1)) LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
 
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -102,8 +102,8 @@ dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
-range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+range_test_x_i=where(((xmin+(psf_dim/2-1)) LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+range_test_y_i=where(((ymin+(psf_dim/2-1)) LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
 
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
 IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
@@ -229,10 +229,10 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
           box_matrix, vis_n, beam_int=beam_int, beam2_int=beam2_int, n_grp_use=n_grp_use,degrid_flag=1,_Extra=extra)
     endif else begin
         IF interp_flag THEN $
-          FOR ii=0L,vis_n-1 DO box_matrix[psf_dim3*ii]=$
+          FOR ii=0L,vis_n-1 DO box_matrix[double(psf_dim3)*ii]=$
             interpolate_kernel(*beam_arr[polarization,fbin[ii],baseline_inds[ii]],x_offset=x_off[ii], $
                 y_offset=y_off[ii],dx0dy0=dx0dy0[ii], dx1dy0=dx1dy0[ii], dx0dy1=dx0dy1[ii], dx1dy1=dx1dy1[ii]) $
-        ELSE FOR ii=0L,vis_n-1 DO box_matrix[psf_dim3*ii]=*(*beam_arr[polarization,fbin[ii],baseline_inds[ii]])[x_off[ii],y_off[ii]] ;more efficient array subscript notation
+        ELSE FOR ii=0L,vis_n-1 DO box_matrix[double(psf_dim3)*ii]=*(*beam_arr[polarization,fbin[ii],baseline_inds[ii]])[x_off[ii],y_off[ii]] ;more efficient array subscript notation
     endelse
 
     t4_0=Systime(1)

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -102,8 +102,8 @@ dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
-range_test_x_i=where(((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-range_test_y_i=where(((ymin+(psf_dim/2-1)) LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
 
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
 IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
@@ -144,7 +144,7 @@ t3=0
 t4=0
 t5=0
 image_uv_use=image_uv
-psf_dim3=psf_dim*psf_dim
+psf_dim3=LONG64(psf_dim*psf_dim)
 
 ;pdim=size(psf_base,/dimension)
 ;psf_base_dag=Ptrarr(pdim,/allocate)
@@ -229,10 +229,10 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
           box_matrix, vis_n, beam_int=beam_int, beam2_int=beam2_int, n_grp_use=n_grp_use,degrid_flag=1,_Extra=extra)
     endif else begin
         IF interp_flag THEN $
-          FOR ii=0L,vis_n-1 DO box_matrix[double(psf_dim3)*ii]=$
+          FOR ii=0L,vis_n-1 DO box_matrix[psf_dim3*ii]=$
             interpolate_kernel(*beam_arr[polarization,fbin[ii],baseline_inds[ii]],x_offset=x_off[ii], $
                 y_offset=y_off[ii],dx0dy0=dx0dy0[ii], dx1dy0=dx1dy0[ii], dx0dy1=dx0dy1[ii], dx1dy1=dx1dy1[ii]) $
-        ELSE FOR ii=0L,vis_n-1 DO box_matrix[double(psf_dim3)*ii]=*(*beam_arr[polarization,fbin[ii],baseline_inds[ii]])[x_off[ii],y_off[ii]] ;more efficient array subscript notation
+        ELSE FOR ii=0L,vis_n-1 DO box_matrix[psf_dim3*ii]=*(*beam_arr[polarization,fbin[ii],baseline_inds[ii]])[x_off[ii],y_off[ii]] ;more efficient array subscript notation
     endelse
 
     t4_0=Systime(1)

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -95,7 +95,7 @@ nbaselines=obs.nbaselines
 n_samples=obs.n_time
 n_freq_use=N_Elements(frequency_array)
 psf_dim2=2*psf_dim
-psf_dim3=psf_dim*psf_dim
+psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
 
 if keyword_set(beam_per_baseline) then begin
@@ -163,8 +163,8 @@ dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
-range_test_x_i=where(((xmin+(psf_dim/2-1)) LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-range_test_y_i=where(((ymin+(psf_dim/2-1)) LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
 
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
 IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -124,10 +124,15 @@ IF Keyword_Set(mapfn_recalculate) THEN BEGIN
     map_fn=Ptrarr(dimension,elements)
 ENDIF ELSE map_flag=0
 
+;Flag baselines on their maximum and minimum extent in the frequency range
 dist_test=Sqrt((kx_arr)^2.+(ky_arr)^2.)*kbinsize
-dist_test=Float(frequency_array#dist_test)
-flag_dist_i=where((dist_test LT min_baseline) OR (dist_test GT max_baseline),n_dist_flag)
+dist_test_max=max((*obs.baseline_info).freq)*dist_test
+dist_test_min=min((*obs.baseline_info).freq)*dist_test
+flag_dist_baseline=where((dist_test_min LT min_baseline) $
+  OR (dist_test_max GT max_baseline),n_dist_flag)
 dist_test=0
+dist_test_min=0
+dist_test_max=0
 
 conj_i=where(ky_arr GT 0,n_conj)
 conj_flag=intarr(N_Elements(ky_arr)) 
@@ -158,15 +163,15 @@ dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
-range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+range_test_x_i=where(((xmin+(psf_dim/2-1)) LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+range_test_y_i=where(((ymin+(psf_dim/2-1)) LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
 
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
 IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
 
 IF n_dist_flag GT 0 THEN BEGIN
-    xmin[flag_dist_i]=-1
-    ymin[flag_dist_i]=-1
+    xmin[*,flag_dist_baseline]=-1
+    ymin[*,flag_dist_baseline]=-1
 ENDIF
 
 IF vis_weight_switch THEN BEGIN


### PR DESCRIPTION
1. Gridding and degridding close to the v=0 line.

Before, whenever a baseline uv-footprint touched the v=0 line, it was flagged. However, I think this is unnecessary. As long as the *center* of the baseline is above v=0, it can be included. This does mean that the footprint will extend into negative v range. In practice, we only grid half of the uv plane and then flip/conjugate and add the two together, which is why I think there was hesitation to include baselines which span both sides of the v=0 line.

I had a good long think about this effect earlier, when I was attempting to do semi-analytic gridding. In that case, a baseline would contribute to *all* of the uv-plane. As long as you grid the top half, but record how that half bleeds downs into the bottom half, the math checks out when you flip/conjugate and add. @miguelfmorales thoughts?

This affect comes in as the `(ymin+(psf_dim/2-1))` lines. I can include PS, but the difference is minor. I don't think there are many baselines which are close to the v=0 line.

2. Double casting the box area pixel total.

When there are many, many baselines, `ii` becomes quite large. `psf_dim3` is a Long. `ii` is a Long. I entered a regime where the multiplication of these two Longs resulted in truncation. By casting psf_dim3 into a Double, I allowed more bits to correct for this issue. This isn't terribly elegant, so I'm open to other suggestions.

3. Flagging baseline extents

Whenever the baseline is too small or too large, it is flagged from the gridding and degridding routines. This was done on a per-frequency basis, which allowed for baselines to disappear halfway through the frequency band. I've changed this so the maximum/minimum extent across the full frequency band is considered when doing this flagging. This allows for a smoother transition along each pixel as a function of frequency, rather than a harsh edge when a baseline disappears. Should fix issue #133.