### PR TITLE
one-mean to zero-mean for regular cable fitting

### DIFF
--- a/fhd_core/calibration/vis_cal_polyfit.pro
+++ b/fhd_core/calibration/vis_cal_polyfit.pro
@@ -274,7 +274,8 @@ FUNCTION vis_cal_polyfit,cal,obs,cal_step_fit=cal_step_fit,cal_neighbor_freq_fla
             gain_temp=rebin(transpose(reform(resautos[freq_use])),nmodes,nf_use)
 
           ENDIF ELSE BEGIN
-            gain_temp=rebin_complex(transpose(reform(gain_arr[freq_use,tile_i])),nmodes,nf_use) ; dimension manipulation, add dim for mode fitting
+            ; dimension manipulation, add dim for mode fitting
+            gain_temp=rebin_complex(transpose(reform(gain_arr[freq_use,tile_i] - mean(gain_arr[freq_use,tile_i]))),nmodes,nf_use)
           ENDELSE
           freq_mat=rebin(transpose(freq_use),nmodes,nf_use) ; freq_use matrix to multiply/collapse in fit
           test_fits=Total(exp(i_comp*2.*!Pi/n_freq*modes*freq_mat)*gain_temp,2) ; Perform DFT of gains to test modes


### PR DESCRIPTION
When incorporating Wenyang's auto ratio branch, I needed to change the convention used in removing the polyfit contribution before cable fitting. This didn't properly percolate to the regular cable fitting.

Therefore, we were taking a hyperfine DFT over something that had a mean of 1 instead of a mean of 0. The associated ringing was rendering the cable reflections useless. 

One of those cases where essentially a `gain = gain - 1` changes the PS significantly....