### PR TITLE
Add simple function to define named structures

### DIFF
--- a/fhd_core/calibration/initialize_fhd_struct.pro
+++ b/fhd_core/calibration/initialize_fhd_struct.pro
@@ -1,0 +1,10 @@
+PRO initialize_fhd_struct, struct_name, obs=obs, params=params
+    ; Create a placeholder copy of the named structure.
+    ; This defines the named structure, which ensures consistency when restoring previously generated structures.
+
+    CASE struct_name OF
+        'cal': struct_init = fhd_struct_init_cal(obs, params)
+        ELSE: print, "Structure of type '" + struct_name + "' is not defined in initialize_fhd_struct.pro; skipping."
+    END
+    undefine_fhd, struct_init
+END

--- a/fhd_core/calibration/vis_calibrate.pro
+++ b/fhd_core/calibration/vis_calibrate.pro
@@ -12,6 +12,7 @@ FUNCTION vis_calibrate,vis_ptr,cal,obs,status_str,psf,params,jones,vis_weight_pt
   t0_0=Systime(1)
   error=0
   timing=-1
+  initialize_fhd_struct, 'cal', obs=obs, params=params
   heap_gc
   IF N_Elements(flag_calibration) EQ 0 THEN flag_calibration=1
   


### PR DESCRIPTION
This simple function creates a placeholder structure of the specified type, and deletes it. This defines the structure parameters for the current IDL session and ensures consistency when restoring structures of that type.