### PR TITLE
Check if metadata flags all tiles

### DIFF
--- a/fhd_core/setup_metadata/fhd_struct_init_meta.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_meta.pro
@@ -45,6 +45,9 @@ IF file_test(metafits_path) THEN BEGIN
     tile_height=meta_data.height
     tile_height=tile_height[single_i]-alt
     tile_flag=Ptrarr(n_pol) & FOR pol_i=0,n_pol-1 DO tile_flag[pol_i]=Ptr_new(meta_data(single_i+pol_i).flag)
+    tile_flag_check=0
+    for pol_i=0,n_pol-1 do tile_flag_check += mean(*tile_flag[pol_i])
+    if tile_flag_check EQ n_pol then message, "ERROR: All tiles flagged in metadata"
     
     obsra=sxpar(meta_hdr,'RA')
     obsdec=sxpar(meta_hdr,'Dec')


### PR DESCRIPTION
Instead of throwing an error after calibration/modelling, throw an error as soon as it's apparent that the metadata has flagged all of the tiles. 

(In the MWA, metadata flags all of the tiles if it did not get reporting stats from the receiver, thus being unable to determine the quality of the array during the obs).