### PR TITLE
Further memory reduction

### DIFF
--- a/fhd_core/beam_modeling/general_antenna_response.pro
+++ b/fhd_core/beam_modeling/general_antenna_response.pro
@@ -11,14 +11,10 @@ response=Ptrarr(n_ant_pol,n_ant)
 nfreq_bin=antenna[0].nfreq_bin
 freq_center=antenna[0].freq
 
-proj_east=Sin(za_arr*DtoR)*Sin(az_arr*DtoR) & proj_east_use=Reform(proj_east,(psf_image_dim)^2.)
-proj_north=Sin(za_arr*DtoR)*Cos(az_arr*DtoR) & proj_north_use=Reform(proj_north,(psf_image_dim)^2.)
-proj_z=Cos(za_arr*DtoR) & proj_z_use=Reform(proj_z,(psf_image_dim)^2.)
-
-;;initialize antenna structure
-;antenna_str={n_pol:n_ant_pol,antenna_type:instrument,model_version:beam_model_version,freq:freq_center,nfreq_bin:nfreq_bin,$
-;    n_ant_elements:0,Jones:Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin),coupling:Ptrarr(n_ant_pol,nfreq_bin),gain:Ptrarr(n_ant_pol),coords:Ptrarr(3),$
-;    delays:Ptr_new(),size_meters:0.,height:0.,group_id:Lonarr(n_ant_pol)-1}
+;Calculate projections only at locations of non-zero pixels
+proj_east_use=Sin(za_arr[pix_use]*DtoR)*Sin(az_arr[pix_use]*DtoR)
+proj_north_use=Sin(za_arr[pix_use]*DtoR)*Cos(az_arr[pix_use]*DtoR)
+proj_z_use=Cos(za_arr[pix_use]*DtoR)
 
 group_arr=antenna.group_id
 FOR pol_i=0,n_ant_pol-1 DO BEGIN
@@ -39,25 +35,25 @@ FOR pol_i=0,n_ant_pol-1 DO BEGIN
         
         ;phase of each dipole for the source (relative to the beamformer settings)
         D_d=(proj_east_use#xc_arr+proj_north_use#yc_arr+proj_z_use#zc_arr)
-        D_d=Reform(D_d,psf_image_dim,psf_image_dim,n_ant_elements)
         
         response_grp=Ptrarr(nfreq_bin)
         FOR freq_i=0L,nfreq_bin-1 DO BEGIN
             response=DComplexarr(N_elements(pix_use))
             Kconv=(2.*!DPi)*(freq_center[freq_i]/c_light_vacuum) 
-            antenna_gain_arr=Exp(-icomp*Kconv*D_d)
             voltage_delay=Exp(icomp*2.*!DPi*delays*(freq_center[freq_i])*Reform((*gain[pol_i])[freq_i,*])) 
             meas_current=(*coupling[pol_i,freq_i])#voltage_delay
             zenith_norm=Mean((*coupling[pol_i,freq_i])#Replicate(1.,n_ant_elements))
             meas_current/=zenith_norm
 
             FOR ii=0L,n_ant_elements-1 DO BEGIN
-                response+=(antenna_gain_arr[*,*,ii]*meas_current[ii]/n_ant_elements)[pix_use]
+                antenna_gain_arr=Exp(-icomp*Kconv*D_d[*,ii])
+                response+=(antenna_gain_arr*meas_current[ii]/n_ant_elements)
             ENDFOR
             response_grp[freq_i]=Ptr_new(response)
         ENDFOR
         FOR g_i=0L,ng-1 DO antenna[g_inds[g_i]].response[pol_i,*]=response_grp
     ENDFOR
 ENDFOR
+
 RETURN,antenna
 END


### PR DESCRIPTION
Implementing strategies used in the past to the general antenna response.

Instead of calculating the general antenna response at every location in the full zero-padded beam image, only calculate it at pixel locations within the horizon (i.e. where it is non-zero). This is a drastic improvement in memory (reducing from 70Gb required to 20Gb on my current test, reduction will be dependent on beam resolution and zero-padding) and a good improvement in time (no reforming required, and no calculating 0 many many times, reduction by a few minutes).