### PR TITLE
Fix box matrix bug and add gridding comments

### DIFF
--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -10,9 +10,8 @@ FUNCTION visibility_grid,visibility_ptr,vis_weight_ptr,obs,status_str,psf,params
 t0_0=Systime(1)
 heap_gc
 
+; Extract information from the structures
 pol_names=obs.pol_names
-
-;extract information from the structures
 dimension=Long(obs.dimension)
 elements=Long(obs.elements)
 kbinsize=obs.kpix
@@ -32,6 +31,7 @@ IF N_Elements(fi_use) EQ 0 THEN fi_use=where((*obs.baseline_info).freq_use)
 freq_bin_i=freq_bin_i[fi_use]
 n_vis_arr=obs.nf_vis
 
+; Careful treatment to avoid overwriting the weights pointer
 vis_weight_switch=Ptr_valid(vis_weight_ptr)
 IF vis_weight_switch THEN BEGIN
     IF Keyword_Set(preserve_visibilities) THEN vis_weights=*vis_weight_ptr ELSE BEGIN
@@ -41,6 +41,8 @@ IF vis_weight_switch THEN BEGIN
 ENDIF
 
 IF N_Elements(bi_use) EQ 0 THEN BEGIN
+    ; If the data is being gridded separatedly for the even/odd time samples, then force
+    ; flagging to be consistent across even/odd sets
     IF vis_weight_switch THEN BEGIN
         flag_test=Total(vis_weights>0,1)
         bi_use=where((flag_test GT 0))
@@ -53,6 +55,8 @@ ENDIF
 n_b_use=N_Elements(bi_use)
 n_f_use=N_Elements(fi_use)
 
+; Calculate indices of visibilities to grid during this call (i.e. specific freqs, time sets)
+; and initialize output arrays
 vis_inds_use=matrix_multiply(fi_use,replicate(1L,n_b_use))+matrix_multiply(replicate(1L,n_f_use),bi_use)*n_freq
 IF vis_weight_switch THEN vis_weights=vis_weights[vis_inds_use]
 IF Keyword_Set(preserve_visibilities) THEN vis_arr_use=(*visibility_ptr)[vis_inds_use] ELSE BEGIN
@@ -88,7 +92,7 @@ uniform_flag=Keyword_Set(uniform_filter)
 uu=params.uu[bi_use]
 vv=params.vv[bi_use]
 ww=params.ww[bi_use]
-kx_arr=uu/kbinsize
+kx_arr=uu/kbinsize ;units in pixel*sec
 ky_arr=vv/kbinsize
 
 nbaselines=obs.nbaselines
@@ -99,6 +103,8 @@ psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
 
 if keyword_set(beam_per_baseline) then begin
+    ; Initialization for gridding operation via a low-res beam kernel, calculated per
+    ; baseline using offsets from image-space delays
     uv_grid_phase_only=1 ;w-terms have not been tested, thus they've been turned off for now
     psf_intermediate_res=(Ceil(Sqrt(psf_resolution)/2)*2.)<psf_resolution
     psf_image_dim=(*psf.image_info).psf_image_dim
@@ -110,6 +116,7 @@ if keyword_set(beam_per_baseline) then begin
     if keyword_set(uv_grid_phase_only) then n_tracked[*]=0
 endif
 
+; Initialize uv-arrays based on double or floating point percision
 IF Keyword_Set(double_precision) THEN image_uv=DComplexarr(dimension,elements) ELSE image_uv=Complexarr(dimension,elements)
 IF Keyword_Set(double_precision) THEN weights=DComplexarr(dimension,elements) ELSE weights=Complexarr(dimension,elements)
 IF Keyword_Set(double_precision) THEN variance=Dblarr(dimension,elements) ELSE variance=Fltarr(dimension,elements)
@@ -124,7 +131,7 @@ IF Keyword_Set(mapfn_recalculate) THEN BEGIN
     map_fn=Ptrarr(dimension,elements)
 ENDIF ELSE map_flag=0
 
-;Flag baselines on their maximum and minimum extent in the frequency range
+; Flag baselines on their maximum and minimum extent in the frequency range
 dist_test=Sqrt((kx_arr)^2.+(ky_arr)^2.)*kbinsize
 dist_test_max=max((*obs.baseline_info).freq)*dist_test
 dist_test_min=min((*obs.baseline_info).freq)*dist_test
@@ -146,35 +153,42 @@ IF n_conj GT 0 THEN BEGIN
     vis_arr_use[*,conj_i]=Conj(vis_arr_use[*,conj_i])
     IF model_flag THEN model_use[*,conj_i]=Conj(model_use[*,conj_i])
 ENDIF
+; Center of baselines for x and y in units of pixels
 xcen=Float(frequency_array#Temporary(kx_arr))
 ycen=Float(frequency_array#Temporary(ky_arr))
 
 x = (FINDGEN(dimension) - dimension/2.)*obs.kpix
 y = (FINDGEN(dimension) - dimension/2.)*obs.kpix
- 
+
+; Pixel number offet per baseline for each uv-box subset 
 x_offset=Fix(Floor((xcen-Floor(xcen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
 y_offset=Fix(Floor((ycen-Floor(ycen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
+; Derivatives from pixel edge to baseline center for use in interpolation
 dx_arr = (xcen-Floor(xcen))*psf_resolution - Floor((xcen-Floor(xcen))*psf_resolution)
 dy_arr = (ycen-Floor(ycen))*psf_resolution - Floor((ycen-Floor(ycen))*psf_resolution)
 dx0dy0_arr = (1-dx_arr)*(1-dy_arr)
 dx0dy1_arr = (1-dx_arr)*dy_arr
 dx1dy0_arr = dx_arr*(1-dy_arr)
 dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
+; The minimum pixel in the uv-grid (bottom left of the kernel) that each baseline contributes to
 xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
 ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
+; Set the minimum pixel value of baselines which fall outside of the uv-grid to -1 to exclude them
 range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
 range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
-
 IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
 IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
 
 IF n_dist_flag GT 0 THEN BEGIN
+    ; If baselines fall outside the desired min/max baseline range at all during the frequency range, 
+    ; then set their minimum pixel value to -1 to exlude them 
     xmin[*,flag_dist_baseline]=-1
     ymin[*,flag_dist_baseline]=-1
 ENDIF
 
 IF vis_weight_switch THEN BEGIN
+    ; If baselines are flagged via the weights, then set their minimum pixel value to -1 to exclude them
     flag_i=where(vis_weights LE 0,n_flag)
     vis_weights=0
     IF n_flag GT 0 THEN BEGIN
@@ -185,6 +199,7 @@ IF vis_weight_switch THEN BEGIN
 ENDIF
 
 IF Keyword_Set(mask_mirror_indices) THEN BEGIN
+    ; Option to exlude v-axis mirrored baselines
     IF n_conj GT 0 THEN BEGIN
         xmin[*,conj_i]=-1
         ymin[*,conj_i]=-1
@@ -192,6 +207,7 @@ IF Keyword_Set(mask_mirror_indices) THEN BEGIN
 ENDIF
 
 IF max(xmin)<max(ymin) LT 0 THEN BEGIN
+    ; Return if all baselines have been flagged
     print,'All data flagged or cut! Returning'
     timing=Systime(1)-t0_0
     image_uv=Complexarr(dimension,elements)
@@ -200,8 +216,9 @@ IF max(xmin)<max(ymin) LT 0 THEN BEGIN
     RETURN,image_uv
 ENDIF
 
-;match all visibilities that map from and to exactly the same pixels
-bin_n=histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0) ;should miss any (xmin,ymin)=(-1,-1) from weights
+; Match all visibilities that map from and to exactly the same pixels and store them as a histogram in bin_n
+; with their respective index ri. Setting min equal to 0 excludes flagged (i.e. (xmin,ymin)=(-1,-1)) data
+bin_n=histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0)
 bin_i=where(bin_n,n_bin_use)
 
 ind_ref=indgen(max(bin_n))
@@ -209,6 +226,7 @@ n_vis=(Total(double(bin_n)))
 FOR fi=0L,n_f_use-1 DO n_vis_arr[fi_use[fi]]=Total(Long(xmin[fi,*] GT 0))
 obs.nf_vis=n_vis_arr
 
+; Initialization based on double or float precision
 index_arr=Lindgen(dimension,elements)
 n_psf_dim=N_Elements(psf_base)
 CASE 1 OF
@@ -235,8 +253,8 @@ IF Keyword_Set(grid_spectral) THEN BEGIN
     ENDIF
 ENDIF
 
-;initialize ONLY those elements of the map_fn array that will receive data
 IF map_flag THEN BEGIN
+    ; Initialize ONLY those elements of the map_fn array that will receive data to remain sparse
     FOR bi=0L,n_bin_use-1 DO BEGIN
         xmin1=xmin[ri[ri[bin_i[bi]]]]
         ymin1=ymin[ri[ri[bin_i[bi]]]]
@@ -309,16 +327,20 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
     ENDIF ELSE BEGIN
         ; Calculate the beam kernel at each baseline location given the hyperresolved pre-calculated
         ; beam kernel
+
+        ; Calculate a unique index for each kernel location and kernel type in order to reduce 
+        ; operations if there are repeats
         group_id=group_arr[inds]
         group_max=Max(group_id)+1
         xyf_i=(x_off+y_off*psf_resolution+fbin*psf_resolution^2.)*group_max+group_id
         
+        ; Calculate the unique number of kernel locations/types
         xyf_si=Sort(xyf_i)
         xyf_i=xyf_i[xyf_si]
         xyf_ui=[Uniq(xyf_i)]
         n_xyf_bin=N_Elements(xyf_ui)
 
-        ;there might be a better selection criteria to determine which is most efficient
+        ; There might be a better selection criteria to determine which is most efficient
         IF vis_n GT 1.1*n_xyf_bin AND ~keyword_set(beam_per_baseline) THEN BEGIN
             ; If there are any baselines which use the same beam kernel and the same discretized location
             ; given the hyperresolution, then reduce the number of gridding operations to only 
@@ -342,6 +364,9 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
                 model_box=model_box1[xyf_ui]
             ENDIF
 
+            ; For the baselines which map to the same pixels and use the same beam,
+            ; add the underlying data/model pixels such that the gridding operation
+            ; only needs to be performed once for the set
             repeat_i=where(psf_weight GT 1,n_rep,complement=single_i,ncom=n_single)
 
             xyf_ui=xyf_ui[repeat_i]
@@ -354,6 +379,8 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
 
             vis_n=n_xyf_bin
         ENDIF ELSE BEGIN
+            ; If there are not enough baselines which use the same beam kernel and discretized
+            ; location to warrent reduction, then perform the gridding operation per baseline
             rep_flag=0
             IF model_flag THEN model_box=model_use[inds]
             vis_box=vis_arr_use[inds]
@@ -427,6 +454,8 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
     IF uniform_flag THEN uniform_filter[xmin_use:xmin_use+psf_dim-1,ymin_use:ymin_use+psf_dim-1]+=bin_n[bin_i[bi]]
     
     IF map_flag THEN BEGIN
+        ; If the mapping function is being calculated, then calculate the beam mapping for the current
+        ; set of uv-pixels and add to the full mapping function
         box_arr_map=matrix_multiply(Temporary(box_matrix),Temporary(box_matrix_dag),/btranspose,TPOOL_MIN_ELTS=20000.)
         FOR i=0,psf_dim-1 DO FOR j=0,psf_dim-1 DO BEGIN
             ij=i+j*psf_dim
@@ -436,7 +465,7 @@ FOR bi=0L,n_bin_use-1 DO BEGIN
     ENDIF
 ENDFOR
 
-;free memory
+; free memory
 vis_arr_use=(model_use=0)
 xmin=(ymin=(ri=(inds=(x_offset=(y_offset=(bin_i=(bin_n=0)))))))
 
@@ -455,6 +484,7 @@ IF map_flag THEN BEGIN
 ENDIF
 
 IF Keyword_Set(grid_spectral) THEN BEGIN
+    ; Option to use spectral index information to scale the uv-plane 
     spectral_uv=(spectral_A-n_vis*spectral_B*image_uv)*weight_invert(spectral_D-spectral_B^2.)
     IF model_flag THEN spectral_model_uv=(spectral_model_A-n_vis*spectral_B*model_return)*weight_invert(spectral_D-spectral_B^2.)
     IF ~Keyword_Set(no_conjugate) THEN BEGIN
@@ -464,6 +494,7 @@ IF Keyword_Set(grid_spectral) THEN BEGIN
 ENDIF
 
 IF Keyword_Set(grid_uniform) THEN BEGIN
+    ; Option to apply a uniform weighted filter to all uv-planes
     filter_use=weight_invert(uniform_filter,1.) 
     wts_i=where(filter_use,n_wts)
     IF n_wts GT 0 THEN filter_use/=Mean(filter_use[wts_i]) ELSE filter_use/=Mean(filter_use)

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -92,7 +92,7 @@ uniform_flag=Keyword_Set(uniform_filter)
 uu=params.uu[bi_use]
 vv=params.vv[bi_use]
 ww=params.ww[bi_use]
-kx_arr=uu/kbinsize ;units in pixel*sec
+kx_arr=uu/kbinsize ;units in pixel/Hz
 ky_arr=vv/kbinsize
 
 nbaselines=obs.nbaselines


### PR DESCRIPTION
In a rarely used option, there was a bug in where the box matrix was being initialized. The value of vis_n changes in this rarely used option, so the box matrix should be initialized right before it is used instead of outside the loop.

I then got carried away and started putting in comments in the gridding function. Help would most definitely be appreciated!