### PR TITLE
Remove gains which don't satisfy conditions from strict convergence

### DIFF
--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -163,6 +163,7 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
             n_arr[tile_i]=n1 ;NEED SOMETHING MORE IN CASE INDIVIDUAL TILES ARE FLAGGED FOR ONLY A FEW FREQUENCIES!!
         ENDFOR
         ;For tiles which don't satisfy the minimum number of solutions, pre-emptively set them to 0
+        ;in order to prevent certain failure in meeting strict convergence threshold
         inds_min_cal = where(n_arr LT min_cal_solutions, n_min_cal)
         if n_min_cal GT 0 then gain_curr[inds_min_cal]=0.
         

--- a/fhd_core/calibration/vis_calibrate_subroutine.pro
+++ b/fhd_core/calibration/vis_calibrate_subroutine.pro
@@ -162,6 +162,9 @@ FUNCTION vis_calibrate_subroutine,vis_ptr,vis_model_ptr,vis_weight_ptr,obs,cal,p
             IF n1 GT 1 THEN *A_ind_arr[tile_i]=Reform(inds,1,n1) ELSE *A_ind_arr[tile_i]=-1
             n_arr[tile_i]=n1 ;NEED SOMETHING MORE IN CASE INDIVIDUAL TILES ARE FLAGGED FOR ONLY A FEW FREQUENCIES!!
         ENDFOR
+        ;For tiles which don't satisfy the minimum number of solutions, pre-emptively set them to 0
+        inds_min_cal = where(n_arr LT min_cal_solutions, n_min_cal)
+        if n_min_cal GT 0 then gain_curr[inds_min_cal]=0.
         
         gain_new=Complexarr(n_tile_use)
         convergence_list = Fltarr(max_cal_iter)


### PR DESCRIPTION
Preemptively set gains which do not satisfy the minimum number of equations set forth in the linear least squares solver to 0. This removes them from the strict convergence threshold, solving issue #258. Otherwise, that frequency generally fails the strict convergence rather quickly. 

It should be noted that this biases the loose convergence threshold (a mean of the tiles for the frequency). However, this was present before as well for other zeroed cases. 