### PR TITLE
Model transfers

### DIFF
--- a/fhd_core/calibration/fhd_struct_init_cal.pro
+++ b/fhd_core/calibration/fhd_struct_init_cal.pro
@@ -9,7 +9,8 @@ FUNCTION fhd_struct_init_cal, obs, params, skymodel, gain_arr_ptr=gain_arr_ptr, 
     cal_mode_fit=cal_mode_fit, file_path_fhd=file_path_fhd, transfer_calibration=transfer_calibration, $
     calibration_auto_initialize=calibration_auto_initialize, cal_gain_init=cal_gain_init, $
     phase_fit_iter=phase_fit_iter, cal_amp_degree_fit=cal_amp_degree_fit,cal_phase_degree_fit=cal_phase_degree_fit, $
-    use_adaptive_calibration_gain=use_adaptive_calibration_gain, calibration_base_gain=calibration_base_gain,_Extra=extra
+    use_adaptive_calibration_gain=use_adaptive_calibration_gain, calibration_base_gain=calibration_base_gain,$
+    min_cal_solutions=min_cal_solutions,_Extra=extra
 
 IF N_Elements(obs) EQ 0 THEN fhd_save_io,0,obs,var='obs',/restore,file_path_fhd=file_path_fhd
 IF N_Elements(params) EQ 0 THEN fhd_save_io,0,params,var='params',/restore,file_path_fhd=file_path_fhd

--- a/fhd_core/calibration/vis_calibrate.pro
+++ b/fhd_core/calibration/vis_calibrate.pro
@@ -98,35 +98,16 @@ FUNCTION vis_calibrate,vis_ptr,cal,obs,status_str,psf,params,jones,vis_weight_pt
 
     ;; Option to transfer pre-made and unflagged model visbilities
     if keyword_set(model_transfer) then begin
-      vis_model_arr=PTRARR(obs.n_pol,/allocate)
-      
-      for pol_i=0, obs.n_pol-1 do begin
-        transfer_name = model_transfer + '/' + obs.obsname + '_vis_model_'+obs.pol_names[pol_i]+'.sav'
-        if ~file_test(transfer_name) then begin
-          message, transfer_name + ' not found during model transfer.'
-        endif
-        vis_model_arr[pol_i] = getvar_savefile(transfer_name,'vis_model_ptr')
-      endfor
+      vis_model_arr = vis_model_transfer(obs,model_transfer)
     endif
 
     RETURN,vis_cal
   ENDIF
-  
-  if ~keyword_set(model_transfer) then begin
-    vis_model_arr=vis_source_model(cal.skymodel,obs,status_str,psf,params,vis_weight_ptr,cal,jones,$
-      model_uv_arr=model_uv_arr,/fill_model_vis,timing=model_timing,silent=silent,error=error,/calibration_flag,$
-      spectral_model_uv_arr=spectral_model_uv_arr,_Extra=extra)
-  endif else begin
-    ;; Option to transfer pre-made and unflagged model visbilities
-    vis_model_arr=PTRARR(obs.n_pol,/allocate)
-
-    for pol_i=0, obs.n_pol-1 do begin
-      transfer_name = model_transfer + '/' + obs.obsname + '_vis_model_'+obs.pol_names[pol_i]+'.sav'
-      if ~file_test(transfer_name) then $
-        message, transfer_name + ' not found during model transfer.'
-      vis_model_arr[pol_i] = getvar_savefile(transfer_name,'vis_model_ptr')
-    endfor
-  endelse
+ 
+  vis_model_arr=vis_source_model(cal.skymodel,obs,status_str,psf,params,vis_weight_ptr,cal,jones,$
+    model_uv_arr=model_uv_arr,/fill_model_vis,timing=model_timing,silent=silent,error=error,/calibration_flag,$
+    spectral_model_uv_arr=spectral_model_uv_arr,model_transfer=model_transfer,_Extra=extra)
+ 
   t1=Systime(1)-t0_0
 
   ;; Option to save unflagged model visibilities as part of a calibration-only loop.

--- a/fhd_core/deconvolution/fast_holographic_deconvolution.pro
+++ b/fhd_core/deconvolution/fast_holographic_deconvolution.pro
@@ -34,7 +34,7 @@ PRO fast_holographic_deconvolution,fhd_params,obs,psf,params,cal,jones,image_uv_
     model_uv_full=model_uv_full,model_uv_holo=model_uv_holo,ra_arr=ra_arr,dec_arr=dec_arr,astr=astr,silent=silent,$
     map_fn_arr=map_fn_arr,transfer_mapfn=transfer_mapfn,beam_base=beam_base,beam_correction=beam_correction,$
     file_path_fhd=file_path_fhd,no_condense_sources=no_condense_sources,source_mask=source_mask,scale_gain=scale_gain,$
-    model_uv_arr=model_uv_arr,use_pointing_center=use_pointing_center,_Extra=extra
+    use_pointing_center=use_pointing_center,_Extra=extra
 compile_opt idl2,strictarrsubs  
 
 ; Deconvolution is divided into several sequential steps:
@@ -247,7 +247,7 @@ IF Keyword_Set(subtract_sidelobe_catalog) THEN BEGIN
         n_sidelobe_src=N_Elements(source_arr_sidelobe)
         print,'Subtracting source model from the sidelobes: '+ Strn(n_sidelobe_src) + " source components"
         IF Keyword_Set(return_sidelobe_catalog) THEN BEGIN
-            print, 'Sidelobe sources included in source list"
+            print, "Sidelobe sources included in source list"
             component_array = [source_arr_sidelobe, component_array]
             max_deconvolution_components += n_sidelobe_src
             comp_i += n_sidelobe_src

--- a/fhd_core/fhd_main.pro
+++ b/fhd_core/fhd_main.pro
@@ -127,7 +127,6 @@ IF data_flag LE 0 THEN BEGIN
     IF Keyword_set(model_uv_transfer) THEN BEGIN
       if ~file_test(model_uv_transfer) then message, model_uv_transfer + ' not found during model uv transfer.'
       model_uv_arr = getvar_savefile(model_uv_transfer,'model_uv_arr')
-      IF Keyword_Set(model_visibilities) THEN model_uv_arr2 = model_uv_arr
     ENDIF
 
     IF Keyword_Set(calibrate_visibilities) THEN BEGIN
@@ -170,11 +169,8 @@ IF data_flag LE 0 THEN BEGIN
         ENDIF
         skymodel_update=fhd_struct_init_skymodel(obs,source_list=model_source_list,catalog_path=model_catalog_file_path,$
             diffuse_model=diffuse_model,return_cal=return_cal_visibilities,_Extra=extra)
-        vis_model_arr=vis_source_model(skymodel_update,obs,status_str,psf,params,vis_weights,0,jones,model_uv_arr=model_uv_arr2,$
-            timing=model_timing,silent=silent,error=error,vis_model_ptr=vis_model_arr,calibration_flag=0,_Extra=extra) 
-        IF Min(Ptr_valid(model_uv_arr)) GT 0 THEN FOR pol_i=0,n_pol-1 DO *model_uv_arr[pol_i]+=*model_uv_arr2[pol_i] $
-            ELSE model_uv_arr=Pointer_copy(model_uv_arr2) 
-        undefine_fhd,model_uv_arr2
+        vis_model_arr=vis_source_model(skymodel_update,obs,status_str,psf,params,vis_weights,0,jones,model_uv_arr=model_uv_arr,$
+            timing=model_timing,silent=silent,error=error,vis_model_ptr=vis_model_arr,calibration_flag=0,file_path_fhd=file_path_fhd,_Extra=extra)
     ENDIF
     
     IF Keyword_Set(skymodel_cal) OR Keyword_Set(skymodel_update) THEN $

--- a/fhd_core/source_modeling/vis_model_transfer.pro
+++ b/fhd_core/source_modeling/vis_model_transfer.pro
@@ -1,0 +1,16 @@
+function vis_model_transfer,obs,model_transfer
+
+  ;; Option to transfer pre-made and unflagged model visbilities
+  vis_model_arr=PTRARR(obs.n_pol,/allocate)
+
+  for pol_i=0, obs.n_pol-1 do begin
+    transfer_name = model_transfer + '/' + obs.obsname + '_vis_model_'+obs.pol_names[pol_i]+'.sav'
+    if ~file_test(transfer_name) then $
+      message, transfer_name + ' not found during model transfer.'
+    vis_model_arr[pol_i] = getvar_savefile(transfer_name,'vis_model_ptr')
+    print, "Model visibilities transferred from " + transfer_name
+  endfor
+
+  return, vis_model_arr
+
+end


### PR DESCRIPTION
Extra instances to transfer 1) model visibilities and 2) a simulated model uv-plane without the instrument. This allows for the code to input model visibilities in a more efficient manner (i.e. in a separate transfer module), or to input a theoretical model uv-plane with only source contributions. The latter is helpful for simulations/parameter changes, and the former is helpful for double data runs (separate kernel for cal and gridding).