### PR TITLE
Adding robust filter

### DIFF
--- a/fhd_output/fft_filters/filter_uv_robust.pro
+++ b/fhd_output/fft_filters/filter_uv_robust.pro
@@ -1,0 +1,31 @@
+FUNCTION filter_uv_robust,image_uv,obs=obs,psf=psf,params=params,weights=weights,name=name,filter=filter,$
+    file_path_fhd=file_path_fhd,return_name_only=return_name_only,robust_param=robust_param,_Extra=extra
+;NOTE: 'params' can actually be EITHER params OR 'cal' structure!
+
+name='robust' + number_formatter(robust_param)
+IF Keyword_Set(return_name_only) THEN RETURN,image_uv
+;NOTE: This does not make use of fine-grained flagging, but relies on coarse flags from the obs structure 
+; (i.e. a list of tiles completely flagged, and of frequencies completely flagged)
+
+IF ~(Keyword_Set(obs) AND Keyword_Set(psf) AND Keyword_Set(params)) THEN BEGIN
+    IF Keyword_Set(file_path_fhd) THEN BEGIN
+        fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+    ENDIF ELSE BEGIN
+        IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv
+        vis_count=weights/Min(weights[where(weights GT 0)])
+    ENDELSE
+ENDIF ELSE BEGIN
+    IF Keyword_Set(file_path_fhd) THEN fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+ENDELSE
+filter_use=1/(1+vis_count*(5.*10^(-robust_param))^2./(total(vis_count^2.)/total(vis_count))) ;should have psf.dim^2. factor, but that would divide out in the normalization later anyway
+
+IF N_Elements(weights) EQ N_Elements(image_uv) THEN wts_i=where(weights,n_wts) ELSE wts_i=where(filter_use,n_wts)
+IF n_wts GT 0 THEN filter_use/=Mean(filter_use[wts_i]) ELSE filter_use/=Mean(filter_use)
+
+IF Ptr_valid(filter) THEN *filter=filter_use
+
+image_uv_filtered=image_uv*filter_use
+RETURN,image_uv_filtered
+END

--- a/fhd_output/fhd_quickview.pro
+++ b/fhd_output/fhd_quickview.pro
@@ -95,7 +95,7 @@ ENDIF
 IF residual_flag THEN model_flag=0
 
 IF Keyword_Set(image_filter_fn) THEN BEGIN
-    dummy_img=Call_function(image_filter_fn,fltarr(2,2),name=filter_name,/return_name_only)
+    dummy_img=Call_function(image_filter_fn,fltarr(2,2),name=filter_name,/return_name_only,_Extra=extra)
     IF Keyword_Set(filter_name) THEN filter_name='_'+filter_name ELSE filter_name=''
 ENDIF ELSE filter_name=''
 


### PR DESCRIPTION
This is an implementation of robust/Briggs weighting for images, where `robust_param` is used to encode the robust scaling. It ranges from -2 to 2, where -2 is close to uniform weighting and 2 is close to natural weighting. Below are simulations of point sources in dirty Stokes I for robust weightings of -2, -1, 0, 1, and 2 (no noise).

Here is a locked DS9 tiled image:
<img width="1183" alt="Screen Shot 2021-09-30 at 2 14 04 pm" src="https://user-images.githubusercontent.com/5588290/135400065-6c42a0bc-c412-42e4-948a-5ad0ba1de863.png">
And again, oversaturated
<img width="1184" alt="Screen Shot 2021-09-30 at 2 13 33 pm" src="https://user-images.githubusercontent.com/5588290/135400111-c4d052ec-ba09-41e1-8607-d4676053d0a7.png">
And a gif of the automatically made FHD images
![image](https://user-images.githubusercontent.com/5588290/135400202-ba136f66-9a86-4d4c-ba3c-04f67da30f07.gif)

The extreme ends look correct (-2 ~ uniform, 2 ~ natural), but I have no frame of reference for in-between values. It would be great if someone experienced in what robust weighting looks like could advise if this is the normal behaviour. 