### PR TITLE
Passing variables into filter functions

### DIFF
--- a/fhd_core/gridding/dirty_image_generate.pro
+++ b/fhd_core/gridding/dirty_image_generate.pro
@@ -1,4 +1,4 @@
-FUNCTION dirty_image_generate,dirty_image_uv,obs=obs,psf=psf,params=params$
+FUNCTION dirty_image_generate,dirty_image_uv,obs=obs,psf=psf,params=params,$
     baseline_threshold=baseline_threshold,mask=mask,$
     normalization=normalization,resize=resize,width_smooth=width_smooth,degpix=degpix,$
     no_real=no_real,image_filter_fn=image_filter_fn,pad_uv_image=pad_uv_image,$

--- a/fhd_core/gridding/dirty_image_generate.pro
+++ b/fhd_core/gridding/dirty_image_generate.pro
@@ -1,4 +1,5 @@
-FUNCTION dirty_image_generate,dirty_image_uv,baseline_threshold=baseline_threshold,mask=mask,$
+FUNCTION dirty_image_generate,dirty_image_uv,obs=obs,psf=psf,params=params$
+    baseline_threshold=baseline_threshold,mask=mask,$
     normalization=normalization,resize=resize,width_smooth=width_smooth,degpix=degpix,$
     no_real=no_real,image_filter_fn=image_filter_fn,pad_uv_image=pad_uv_image,$
     filter=filter,weights=weights,antialias=antialias,beam_ptr=beam_ptr,_Extra=extra
@@ -30,16 +31,19 @@ IF Keyword_Set(filter) THEN BEGIN
         IF N_Elements(*filter) EQ N_Elements(di_uv_use) THEN di_uv_use*=*filter $
             ELSE BEGIN
                 IF ~Keyword_Set(image_filter_fn) THEN image_filter_fn='filter_uv_uniform'
-                di_uv_use=Call_Function(image_filter_fn,di_uv_use,weights=weights,filter=filter,_Extra=extra)
+                di_uv_use=Call_Function(image_filter_fn,di_uv_use,obs=obs,psf=psf,params=params,$
+                    weights=weights,filter=filter,_Extra=extra)
             ENDELSE
     ENDIF ELSE BEGIN
         filter=Ptr_new(/allocate)
         IF N_Elements(image_filter_fn) EQ 0 THEN image_filter_fn='filter_uv_uniform'
-        di_uv_use=Call_Function(image_filter_fn,di_uv_use,weights=weights,filter=filter,_Extra=extra)
+        di_uv_use=Call_Function(image_filter_fn,di_uv_use,obs=obs,psf=psf,params=params,$
+            weights=weights,filter=filter,_Extra=extra)
     ENDELSE
 ENDIF ELSE BEGIN
     IF Keyword_Set(image_filter_fn) THEN $
-        di_uv_use=Call_Function(image_filter_fn,di_uv_use,weights=weights,filter=filter,_Extra=extra)
+        di_uv_use=Call_Function(image_filter_fn,di_uv_use,obs=obs,psf=psf,params=params,$
+            weights=weights,filter=filter,_Extra=extra)
 ENDELSE
 
 ;IF Keyword_Set(antialias) THEN BEGIN

--- a/fhd_output/fft_filters/filter_uv_hanning.pro
+++ b/fhd_output/fft_filters/filter_uv_hanning.pro
@@ -1,4 +1,5 @@
-FUNCTION filter_uv_hanning,image_uv,name=name,weights=weights,filter=filter,return_name_only=return_name_only,_Extra=extra
+FUNCTION filter_uv_hanning,image_uv,obs=obs,psf=psf,params=params,name=name,$
+    weights=weights,filter=filter,return_name_only=return_name_only,_Extra=extra
 name='hanning'
 IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv
@@ -27,7 +28,8 @@ IF Max(filter_use) EQ 0 THEN RETURN,image_uv
 filter_use *= hanning(dimension,elements)
 
 wts_i=where(weights,n_wts)
-IF n_wts GT 0 THEN filter_use=filter_use*mean(weights[wts_i])/Mean(weights[wts_i]*filter_use[wts_i]) ELSE filter_use=filter_use*mean(weights)/Mean(weights*filter_use)
+IF n_wts GT 0 THEN filter_use=filter_use*mean(weights[wts_i])/Mean(weights[wts_i]*filter_use[wts_i]) $
+    ELSE filter_use=filter_use*mean(weights)/Mean(weights*filter_use)
 
 IF Ptr_valid(filter) THEN *filter=filter_use
 

--- a/fhd_output/fft_filters/filter_uv_natural.pro
+++ b/fhd_output/fft_filters/filter_uv_natural.pro
@@ -1,5 +1,5 @@
-FUNCTION filter_uv_natural,image_uv,name=name,weights=weights,filter=filter,$
-    return_name_only=return_name_only,_Extra=extra
+FUNCTION filter_uv_natural,image_uv,obs=obs,psf=psf,params=params,name=name,weights=weights,$
+    filter=filter,return_name_only=return_name_only,_Extra=extra
 name='natural'
 IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv

--- a/fhd_output/fft_filters/filter_uv_optimal.pro
+++ b/fhd_output/fft_filters/filter_uv_optimal.pro
@@ -9,14 +9,17 @@ IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 IF ~(Keyword_Set(obs) AND Keyword_Set(psf) AND Keyword_Set(params)) THEN BEGIN
     IF Keyword_Set(file_path_fhd) THEN BEGIN
         fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra) 
+        IF ~Keyword_Set(vis_count) $
+            THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra) 
     ENDIF ELSE BEGIN
         IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv
         vis_count=weights/Min(weights[where(weights GT 0)])
     ENDELSE
 ENDIF ELSE BEGIN
-    IF Keyword_Set(file_path_fhd) THEN fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+    IF Keyword_Set(file_path_fhd) THEN $
+        fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+    IF ~Keyword_Set(vis_count) THEN $
+        vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
 ENDELSE
 
 

--- a/fhd_output/fft_filters/filter_uv_radial.pro
+++ b/fhd_output/fft_filters/filter_uv_radial.pro
@@ -1,5 +1,5 @@
-FUNCTION filter_uv_radial,image_uv,name=name,weights=weights,filter=filter,$
-    radial_power=radial_power,return_name_only=return_name_only,_Extra=extra
+FUNCTION filter_uv_radial,image_uv,obs=obs,psf=psf,params=params,name=name,weights=weights,$
+    filter=filter,radial_power=radial_power,return_name_only=return_name_only,_Extra=extra
 name='radial'
 IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 ;IF N_Elements(filter) EQ N_Elements(image_uv) THEN RETURN,image_uv*filter
@@ -42,7 +42,8 @@ filter_use=Reform(interpol(rad_vals_use,rad_i_use,reform(radial_map,dimension*Fl
 
 IF Max(filter_use) EQ 0 THEN RETURN,image_uv 
 
-IF Keyword_Set(radial_power) THEN filter_use*=radial_map^radial_power ELSE filter_use*=weight_invert(Sqrt(radial_map))
+IF Keyword_Set(radial_power) THEN filter_use*=radial_map^radial_power $
+    ELSE filter_use*=weight_invert(Sqrt(radial_map))
 wts_i=where(weights,n_wts)
 IF n_wts GT 0 THEN filter_use/=Mean(filter_use[wts_i]) ELSE filter_use/=Mean(filter_use)
 

--- a/fhd_output/fft_filters/filter_uv_uniform.pro
+++ b/fhd_output/fft_filters/filter_uv_uniform.pro
@@ -16,11 +16,14 @@ IF ~(Keyword_Set(obs) AND Keyword_Set(psf) AND Keyword_Set(params)) THEN BEGIN
         vis_count=weights/Min(weights[where(weights GT 0)])
     ENDELSE
 ENDIF ELSE BEGIN
-    IF Keyword_Set(file_path_fhd) THEN fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+    IF Keyword_Set(file_path_fhd) THEN $
+        fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+    IF ~Keyword_Set(vis_count) THEN $
+        vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
 ENDELSE
 ;vis_count[where(vis_count)]=vis_count[where(vis_count)]>(Max(vis_count)/1000.)
-filter_use=weight_invert(vis_count,1.) ;should have psf.dim^2. factor, but that would divide out in the normalization later anyway
+;should have psf.dim^2. factor, but that would divide out in the normalization later anyway
+filter_use=weight_invert(vis_count,1.) 
 
 IF N_Elements(weights) EQ N_Elements(image_uv) THEN wts_i=where(weights,n_wts) ELSE wts_i=where(filter_use,n_wts)
 IF n_wts GT 0 THEN filter_use/=Mean(filter_use[wts_i]) ELSE filter_use/=Mean(filter_use)


### PR DESCRIPTION
If `obs`,`psf`, and `params` are passed into `filter_uv_uniform`, then the visibility count needed for weighting is calculated on the fly. If not, then the `vis_count` file is restored. However, the above structs were not passed into the filter function in `dirty_image_generate`. 

I may see why...the filter function call in `dirty_image_generate` is general, i.e. it can call any filter function depending on input. Some of the simpler filter functions don't need `obs`,`psf`, and `params` to calculate their filter. 

I think that it's better to not rely on I/O, so I've added the structs as passable variables in each filter function, even if they aren't explicitly needed, just so the general filter function call won't fail in `dirty_image_generate`. This is a matter of opinion, so please decline if you don't think it's worth it.