### PR TITLE
Redundant code to a single file

### DIFF
--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -1,10 +1,12 @@
 ;;
-;; Calculate the minimum pixel number that an unflagged baseline contributes to (depending on the 
+;; Calculate the histogram of baseline grid locations in units of pixels whilst also
+;; returning the minimum pixel number that an unflagged baseline contributes to (depending on the 
 ;; size of the kernel). Optionally return the 2D derivatives for bilinear interpolation and the
 ;; indices of the unflagged baselines/frequencies.
 ;;
 
-pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
+Function baseline_grid_locations,obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,ri=ri,$
+  xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
   fill_model_visibilities=fill_model_visibilities,bi_use=bi_use,fi_use=fi_use,$
   vis_inds_use=vis_inds_use,interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
   dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,x_offset=x_offset,y_offset=y_offset,$
@@ -154,5 +156,12 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
       ymin[*,conj_i]=-1
     ENDIF
   ENDIF
+
+  ; Match all visibilities that map from and to exactly the same pixels and store them as a histogram in bin_n
+  ; with their respective index ri. Setting min equal to 0 excludes flagged (i.e. (xmin,ymin)=(-1,-1)) data
+  bin_n=Long(histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0))
+  bin_i=Long(where(bin_n,n_bin_use))
+
+  return, bin_n
 
 END

--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -95,6 +95,12 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
   xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
   ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
+  ; Set the minimum pixel value of baselines which fall outside of the uv-grid to -1 to exclude them
+  range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+  range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+  IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
+  IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
+  
   IF n_dist_flag GT 0 AND ~keyword_set(fill_model_visibilities) THEN BEGIN
     ; If baselines fall outside the desired min/max baseline range at all during the frequency range, 
     ; then set their minimum pixel value to -1 to exlude them 
@@ -102,12 +108,6 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
     ymin[*,flag_dist_baseline]=-1
     flag_dist_baseline=0
   ENDIF
-
-  ; Set the minimum pixel value of baselines which fall outside of the uv-grid to -1 to exclude them
-  range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-  range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
-  IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
-  IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
 
   IF vis_weight_switch THEN BEGIN
     ; If baselines are flagged via the weights, then set their minimum pixel value to -1 to exclude them

--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -80,10 +80,6 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
   ; Pixel number offet per baseline for each uv-box subset 
   x_offset=Fix(Floor((xcen-Floor(xcen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
   y_offset=Fix(Floor((ycen-Floor(ycen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
-
-  ; The minimum pixel in the uv-grid (bottom left of the kernel) that each baseline contributes to
-  xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
-  ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
   
   IF keyword_set(interp_flag) THEN BEGIN
     ; Derivatives from pixel edge to baseline center for use in interpolation
@@ -94,6 +90,10 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
     dx1dy0_arr = dx_arr*(1-dy_arr)
     dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
   ENDIF
+
+  ; The minimum pixel in the uv-grid (bottom left of the kernel) that each baseline contributes to
+  xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
+  ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
 
   IF n_dist_flag GT 0 AND ~keyword_set(fill_model_visibilities) THEN BEGIN
     ; If baselines fall outside the desired min/max baseline range at all during the frequency range, 

--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -30,13 +30,22 @@ pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vi
   n_freq_use=N_Elements(frequency_array)
 
   ; Careful treatment to avoid overwriting the weights pointer
-  vis_weight_switch=Ptr_valid(vis_weight_ptr)
-  IF vis_weight_switch THEN BEGIN
-    IF Keyword_Set(preserve_visibilities) THEN vis_weights=*vis_weight_ptr ELSE BEGIN
-      vis_weights=Temporary(*vis_weight_ptr)
-      Ptr_free,vis_weight_ptr
-    ENDELSE
-  ENDIF
+  weight_type = size(vis_weight_ptr,/type)
+  IF weight_type EQ 10 THEN BEGIN
+    ; If the weights are pointers
+    vis_weight_switch=Ptr_valid(vis_weight_ptr)
+    IF vis_weight_switch THEN BEGIN
+      IF Keyword_Set(preserve_visibilities) THEN vis_weights=*vis_weight_ptr ELSE BEGIN
+        vis_weights=Temporary(*vis_weight_ptr)
+        Ptr_free,vis_weight_ptr
+      ENDELSE
+    ENDIF
+  ENDIF ELSE BEGIN
+    ; If the weights are not pointers
+    vis_weight_switch=1
+    vis_weights = vis_weight_ptr
+    vis_weight_ptr=0
+  ENDELSE
 
   ; Baselines to use
   IF N_Elements(bi_use) EQ 0 THEN BEGIN

--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -1,0 +1,132 @@
+;;
+;; Calculate the minimum pixel number that an unflagged baseline contributes to (depending on the 
+;; size of the kernel). Optionally return the 2D derivatives for bilinear interpolation and the
+;; indices of the unflagged baselines/frequencies.
+;;
+
+pro baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
+  fill_model_visibilities=fill_model_visibilities,bi_use=bi_use,fi_use=fi_use,$
+  interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,$
+  dx1dy1_arr=dx1dy1_arr,mask_mirror_indices=mask_mirror_indices
+
+  ; Extract information from the structures
+  n_tile=obs.n_tile
+  n_freq=obs.n_freq
+  dimension=Long(obs.dimension)
+  elements=Long(obs.elements)
+  kbinsize=obs.kpix
+  min_baseline=obs.min_baseline
+  max_baseline=obs.max_baseline
+  b_info=*obs.baseline_info
+  psf_dim=psf.dim
+  psf_resolution=psf.resolution
+
+  ; Frequency information of the visibilities
+  IF N_Elements(fi_use) EQ 0 THEN fi_use=where(b_info.freq_use)
+  IF Keyword_Set(fill_model_visibilities) THEN fi_use=lindgen(n_freq)
+  frequency_array=b_info.freq
+  frequency_array=frequency_array[fi_use]
+  n_freq_use=N_Elements(frequency_array)
+
+  ; Careful treatment to avoid overwriting the weights pointer
+  vis_weight_switch=Ptr_valid(vis_weight_ptr)
+  IF vis_weight_switch THEN BEGIN
+    IF Keyword_Set(preserve_visibilities) THEN vis_weights=*vis_weight_ptr ELSE BEGIN
+      vis_weights=Temporary(*vis_weight_ptr)
+      Ptr_free,vis_weight_ptr
+    ENDELSE
+  ENDIF
+
+  ; Baselines to use
+  IF N_Elements(bi_use) EQ 0 THEN BEGIN
+    ; If the data is being gridded separatedly for the even/odd time samples, then force
+    ; flagging to be consistent across even/odd sets
+    IF vis_weight_switch AND ~Keyword_set(fill_model_vis) THEN BEGIN
+      flag_test=Total(vis_weights>0,1)
+      bi_use=where((flag_test GT 0))
+    ENDIF ELSE BEGIN
+      b_info=(*obs.baseline_info)
+      tile_use=where(b_info.tile_use)+1
+      IF Keyword_Set(fill_model_visibilities) THEN tile_use=lindgen(n_tile)+1
+      bi_use=array_match(b_info.tile_A,b_info.tile_B,value_match=tile_use)
+    ENDELSE
+  ENDIF
+
+  ; Units in pixel/Hz
+  kx_arr=params.uu[bi_use]/kbinsize
+  ky_arr=params.vv[bi_use]/kbinsize
+
+  ; Flag baselines on their maximum and minimum extent in the full frequency range of the observation
+  dist_test=Sqrt((kx_arr)^2.+(ky_arr)^2.)*kbinsize
+  dist_test_max=max((*obs.baseline_info).freq)*dist_test
+  dist_test_min=min((*obs.baseline_info).freq)*dist_test
+  flag_dist_baseline=where((dist_test_min LT min_baseline) $
+    OR (dist_test_max GT max_baseline),n_dist_flag)
+  dist_test=0
+  dist_test_min=0
+  dist_test_max=0
+
+  ; Create the other half of the uv plane via negating the locations
+  conj_i=where(ky_arr GT 0,n_conj)
+  IF n_conj GT 0 THEN BEGIN
+    kx_arr[conj_i]=-kx_arr[conj_i]
+    ky_arr[conj_i]=-ky_arr[conj_i]
+  ENDIF
+
+  ; Center of baselines for x and y in units of pixels
+  xcen=Float(frequency_array#Temporary(kx_arr))
+  ycen=Float(frequency_array#Temporary(ky_arr))
+
+  ; Pixel number offet per baseline for each uv-box subset 
+  x_offset=Fix(Floor((xcen-Floor(xcen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
+  y_offset=Fix(Floor((ycen-Floor(ycen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
+
+  ; The minimum pixel in the uv-grid (bottom left of the kernel) that each baseline contributes to
+  xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
+  ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
+  
+  IF keyword_set(interp_flag) THEN BEGIN
+    ; Derivatives from pixel edge to baseline center for use in interpolation
+    dx_arr = (xcen-Floor(xcen))*psf_resolution - Floor((xcen-Floor(xcen))*psf_resolution)
+    dy_arr = (ycen-Floor(ycen))*psf_resolution - Floor((ycen-Floor(ycen))*psf_resolution)
+    dx0dy0_arr = (1-dx_arr)*(1-dy_arr)
+    dx0dy1_arr = (1-dx_arr)*dy_arr
+    dx1dy0_arr = dx_arr*(1-dy_arr)
+    dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
+  ENDIF
+
+  IF n_dist_flag GT 0 AND ~keyword_set(fill_model_visibilities) THEN BEGIN
+    ; If baselines fall outside the desired min/max baseline range at all during the frequency range, 
+    ; then set their minimum pixel value to -1 to exlude them 
+    xmin[*,flag_dist_baseline]=-1
+    ymin[*,flag_dist_baseline]=-1
+    flag_dist_baseline=0
+  ENDIF
+
+  ; Set the minimum pixel value of baselines which fall outside of the uv-grid to -1 to exclude them
+  range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
+  range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
+  IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
+  IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
+
+  IF vis_weight_switch THEN BEGIN
+    ; If baselines are flagged via the weights, then set their minimum pixel value to -1 to exclude them
+    flag_i=where(vis_weights LE 0,n_flag)
+    IF Keyword_Set(fill_model_visibilities) THEN n_flag=0L
+    IF n_flag GT 0 THEN BEGIN
+      xmin[flag_i]=-1
+      ymin[flag_i]=-1
+    ENDIF
+    vis_weights=0
+    flag_i=0
+  ENDIF
+
+  IF Keyword_Set(mask_mirror_indices) THEN BEGIN
+    ; Option to exlude v-axis mirrored baselines
+    IF n_conj GT 0 THEN BEGIN
+      xmin[*,conj_i]=-1
+      ymin[*,conj_i]=-1
+    ENDIF
+  ENDIF
+
+END

--- a/fhd_core/gridding/visibility_count.pro
+++ b/fhd_core/gridding/visibility_count.pro
@@ -1,13 +1,18 @@
 FUNCTION visibility_count,obs,psf,params,vis_weight_ptr=vis_weight_ptr,file_path_fhd=file_path_fhd,$
-    preserve_visibilities=preserve_visibilities,no_conjugate=no_conjugate,fill_model_vis=fill_model_vis,
+    preserve_visibilities=preserve_visibilities,no_conjugate=no_conjugate,fill_model_vis=fill_model_vis,$
     double_precision=double_precision,bi_use=bi_use,fi_use=fi_use,n_freq_use=n_freq_use,xmin=xmin,ymin=ymin,$
-    mask_mirror_indicies=mask_mirror_indicies,_Extra=extra
+    mask_mirror_indices=mask_mirror_indices,_Extra=extra
 
 IF N_Elements(obs) EQ 0 THEN fhd_save_io,status_str,obs,var='obs',/restore,file_path_fhd=file_path_fhd,_Extra=extra
 IF N_Elements(psf) EQ 0 THEN fhd_save_io,status_str,psf,var='psf',/restore,file_path_fhd=file_path_fhd,_Extra=extra
 IF N_Elements(params) EQ 0 THEN fhd_save_io,status_str,params,var='params',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-IF Min(ptr_valid(vis_weight_ptr)) EQ 0 THEN $
+
+weight_type = size(vis_weight_ptr,/type)
+IF (weight_type EQ 10) OR (weight_type EQ 0) THEN BEGIN
+  ; If the weights are pointers or undefined
+  IF Min(ptr_valid(vis_weight_ptr)) EQ 0 THEN $
     fhd_save_io,status_str,vis_weight_ptr,var='vis_weights',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+ENDIF
 
 ;extract information from the structures
 dimension=Long(obs.dimension)
@@ -15,7 +20,7 @@ elements=Long(obs.elements)
 
 ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
 baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,fill_model_vis=fill_model_vis,$
-    bi_use=bi_use,fi_use=fi_use,mask_mirror_indicies=mask_mirror_indicies
+    bi_use=bi_use,fi_use=fi_use,mask_mirror_indices=mask_mirror_indices
 
 ; Match all visibilities that map from and to exactly the same pixels and store them as a histogram in bin_n
 ; with their respective index ri. Setting min equal to 0 excludes flagged (i.e. (xmin,ymin)=(-1,-1)) data

--- a/fhd_core/gridding/visibility_count.pro
+++ b/fhd_core/gridding/visibility_count.pro
@@ -19,16 +19,11 @@ dimension=Long(obs.dimension)
 elements=Long(obs.elements)
 
 ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
-baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,fill_model_vis=fill_model_vis,$
-    bi_use=bi_use,fi_use=fi_use,mask_mirror_indices=mask_mirror_indices
+bin_n=baseline_grid_locations(obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,ri=ri,$
+    xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,fill_model_vis=fill_model_vis,$
+    bi_use=bi_use,fi_use=fi_use,mask_mirror_indices=mask_mirror_indices)
 
-; Match all visibilities that map from and to exactly the same pixels and store them as a histogram in bin_n
-; with their respective index ri. Setting min equal to 0 excludes flagged (i.e. (xmin,ymin)=(-1,-1)) data
-bin_n=histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0)
-bin_i=where(bin_n,n_bin_use)
-
-double_precision=0
-IF Tag_Exist(obs, 'double_precision') THEN double_precision=obs.double_precision
+double_precision=obs.double_precision
 IF Keyword_Set(double_precision) THEN uniform_filter=Dblarr(dimension,elements) ELSE uniform_filter=Fltarr(dimension,elements)
 FOR bi=0L,n_bin_use-1 DO BEGIN
     inds=ri[ri[bin_i[bi]]:ri[bin_i[bi]+1]-1]

--- a/fhd_core/gridding/visibility_count.pro
+++ b/fhd_core/gridding/visibility_count.pro
@@ -1,106 +1,42 @@
 FUNCTION visibility_count,obs,psf,params,vis_weight_ptr=vis_weight_ptr,file_path_fhd=file_path_fhd,$
-    no_conjugate=no_conjugate,fill_model_vis=fill_model_vis,_Extra=extra
+    preserve_visibilities=preserve_visibilities,no_conjugate=no_conjugate,fill_model_vis=fill_model_vis,
+    double_precision=double_precision,bi_use=bi_use,fi_use=fi_use,n_freq_use=n_freq_use,xmin=xmin,ymin=ymin,$
+    mask_mirror_indicies=mask_mirror_indicies,_Extra=extra
 
 IF N_Elements(obs) EQ 0 THEN fhd_save_io,status_str,obs,var='obs',/restore,file_path_fhd=file_path_fhd,_Extra=extra
 IF N_Elements(psf) EQ 0 THEN fhd_save_io,status_str,psf,var='psf',/restore,file_path_fhd=file_path_fhd,_Extra=extra
 IF N_Elements(params) EQ 0 THEN fhd_save_io,status_str,params,var='params',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-IF Min(ptr_valid(vis_weight_ptr)) EQ 0 THEN fhd_save_io,status_str,vis_weight_ptr,var='vis_weights',/restore,file_path_fhd=file_path_fhd,_Extra=extra
+IF Min(ptr_valid(vis_weight_ptr)) EQ 0 THEN $
+    fhd_save_io,status_str,vis_weight_ptr,var='vis_weights',/restore,file_path_fhd=file_path_fhd,_Extra=extra
 
 ;extract information from the structures
-n_pol=obs.n_pol
-n_tile=obs.n_tile
-n_freq=obs.n_freq
 dimension=Long(obs.dimension)
 elements=Long(obs.elements)
-kbinsize=obs.kpix
-kx_span=kbinsize*Float(dimension) ;Units are # of wavelengths
-ky_span=kx_span
-min_baseline=obs.min_baseline
-max_baseline=obs.max_baseline
-b_info=*obs.baseline_info
 
-freq_bin_i=b_info.fbin_i
-fi_use=where(b_info.freq_use)
-IF Keyword_Set(fill_model_vis) THEN fi_use=lindgen(n_freq)
-freq_bin_i=freq_bin_i[fi_use]
+; For each unflagged baseline, get the minimum contributing pixel number for gridding 
+baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,fill_model_vis=fill_model_vis,$
+    bi_use=bi_use,fi_use=fi_use,mask_mirror_indicies=mask_mirror_indicies
 
-frequency_array=b_info.freq
-frequency_array=frequency_array[fi_use]
-
-tile_use=where(b_info.tile_use)+1
-IF Keyword_Set(fill_model_vis) THEN tile_use=lindgen(n_tile)+1
-bi_use=array_match(b_info.tile_A,b_info.tile_B,value_match=tile_use)
-n_b_use=N_Elements(bi_use)
-n_f_use=N_Elements(fi_use)
-
-psf_dim=psf.dim
-psf_resolution=psf.resolution
-
-kx_arr=params.uu[bi_use]/kbinsize
-ky_arr=params.vv[bi_use]/kbinsize
-
-dist_test=Sqrt((kx_arr)^2.+(ky_arr)^2.)*kbinsize
-dist_test=frequency_array#dist_test
-flag_dist_i=where((dist_test LT min_baseline) OR (dist_test GT max_baseline),n_dist_flag)
-dist_test=0
-
-xcen=frequency_array#kx_arr
-ycen=frequency_array#ky_arr
-
-conj_i=where(ky_arr GT 0,n_conj)
-IF n_conj GT 0 THEN BEGIN
-    xcen[*,conj_i]=-xcen[*,conj_i]
-    ycen[*,conj_i]=-ycen[*,conj_i]
-ENDIF
-
-xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
-ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
-
-IF n_dist_flag GT 0 THEN BEGIN
-    xmin[flag_dist_i]=-1
-    ymin[flag_dist_i]=-1
-    flag_dist_i=0
-ENDIF
-
-range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
-range_test_x_i=0
-range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
-IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
-range_test_y_i=0
-
-IF Keyword_Set(vis_weight_ptr) THEN BEGIN
-    flag_i=where(*vis_weight_ptr[0] LE 0,n_flag,ncomplement=n_unflag)
-    IF Keyword_Set(fill_model_vis) THEN n_flag=0L
-    IF n_flag GT 0 THEN BEGIN
-        xmin[flag_i]=-1
-        ymin[flag_i]=-1
-    ENDIF
-    IF ~Arg_present(vis_weight_ptr) THEN undefine_fhd,vis_weight_ptr
-ENDIF
-IF ~Arg_present(obs) THEN undefine_fhd,obs
-IF ~Arg_present(params) THEN undefine_fhd,params
-IF ~Arg_present(psf) THEN undefine_fhd,psf
-
-;match all visibilities that map from and to exactly the same pixels
-bin_n=histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0) ;should miss any (xmin,ymin)=(-1,-1) from weights
+; Match all visibilities that map from and to exactly the same pixels and store them as a histogram in bin_n
+; with their respective index ri. Setting min equal to 0 excludes flagged (i.e. (xmin,ymin)=(-1,-1)) data
+bin_n=histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0)
 bin_i=where(bin_n,n_bin_use)
 
-weights=fltarr(dimension,elements)
+double_precision=0
+IF Tag_Exist(obs, 'double_precision') THEN double_precision=obs.double_precision
+IF Keyword_Set(double_precision) THEN uniform_filter=Dblarr(dimension,elements) ELSE uniform_filter=Fltarr(dimension,elements)
 FOR bi=0L,n_bin_use-1 DO BEGIN
     inds=ri[ri[bin_i[bi]]:ri[bin_i[bi]+1]-1]
     ind0=inds[0]
     
     xmin_use=xmin[ind0] ;should all be the same, but don't want an array
     ymin_use=ymin[ind0]
-    weights[xmin_use:xmin_use+psf_dim-1,ymin_use:ymin_use+psf_dim-1]+=bin_n[bin_i[bi]]
+    uniform_filter[xmin_use:xmin_use+psf_dim-1,ymin_use:ymin_use+psf_dim-1]+=bin_n[bin_i[bi]]
 ENDFOR
     
-IF ~Keyword_Set(no_conjugate) THEN BEGIN
-    weights_mirror=Shift(Reverse(reverse(weights,1),2),1,1)
-    weights=(weights+weights_mirror)/2.
-ENDIF
+IF ~Keyword_Set(no_conjugate) THEN uniform_filter=(uniform_filter+conjugate_mirror(uniform_filter))/2.
 
-fhd_save_io,status_str,weights,var='vis_count',file_path_fhd=file_path_fhd,_Extra=extra
-RETURN,weights
+fhd_save_io,status_str,uniform_filter,var='vis_count',file_path_fhd=file_path_fhd,_Extra=extra
+
+RETURN,uniform_filter
 END

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -20,7 +20,8 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
     ; and the 2D derivatives for bilinear interpolation
     baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
       fill_model_visibilities=fill_model_visibilities,interp_flag=interp_flag,$
-      dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr
+      dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,$
+      x_offset=x_offset,y_offset=y_offset
 
     ;extract information from the structures
     dimension=Long(obs.dimension)

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -9,19 +9,19 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
 
     complex=psf.complex_flag
     n_spectral=obs.degrid_spectral_terms
-    double_precision=0
-    IF Tag_Exist(obs, 'double_precision') THEN double_precision=obs.double_precision
-    IF Tag_exist(psf,'interpolate_kernel') THEN interp_flag=psf.interpolate_kernel ELSE interp_flag=0
+    double_precision=obs.double_precision
+    interp_flag=psf.interpolate_kernel
     IF keyword_set(conserve_memory) then begin
         IF conserve_memory GT 1E6 THEN mem_thresh=conserve_memory ELSE mem_thresh=1E8 ;in bytes
     ENDIF
 
     ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
     ; and the 2D derivatives for bilinear interpolation
-    baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
+    bin_n=baseline_grid_locations(obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,ri=ri,$
+      xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
       fill_model_visibilities=fill_model_visibilities,interp_flag=interp_flag,$
       dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,$
-      x_offset=x_offset,y_offset=y_offset
+      x_offset=x_offset,y_offset=y_offset)
 
     ;extract information from the structures
     dimension=Long(obs.dimension)
@@ -81,10 +81,6 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
     vis_dimension=nbaselines*n_samples
     IF Keyword_Set(double_precision) THEN visibility_array=DComplexarr(n_freq,vis_dimension) $
     ELSE visibility_array=Complexarr(n_freq,vis_dimension)
-    
-    ;match all visibilities that map from and to exactly the same pixels
-    bin_n=Long(histogram(xmin+ymin*dimension,binsize=1,reverse_indices=ri,min=0)) ;should miss any (xmin,ymin)=(-1,-1) from weights
-    bin_i=Long(where(bin_n,n_bin_use));+bin_min
 
     ind_ref=Lindgen(max(bin_n))
 

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -19,9 +19,8 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
     ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
     ; and the 2D derivatives for bilinear interpolation
     baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
-      fill_model_visibilities=fill_model_visibilities,bi_use=bi_use,fi_use=fi_use,$
-      interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
-      dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,mask_mirror_indices=mask_mirror_indices
+      fill_model_visibilities=fill_model_visibilities,interp_flag=interp_flag,$
+      dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr
 
     ;extract information from the structures
     dimension=Long(obs.dimension)

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -21,7 +21,7 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
     baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
       fill_model_visibilities=fill_model_visibilities,bi_use=bi_use,fi_use=fi_use,$
       interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
-      dx1dy0_arr=dx1dy0_arr,mask_mirror_indicies=mask_mirror_indicies
+      dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,mask_mirror_indices=mask_mirror_indices
 
     ;extract information from the structures
     dimension=Long(obs.dimension)

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -108,7 +108,7 @@ IF Keyword_Set(mapfn_recalculate) THEN BEGIN
     map_fn=Ptrarr(dimension,elements)
 ENDIF ELSE map_flag=0
 
-conj_i=where(params.vv GT 0,n_conj)
+conj_i=where(params.vv[bi_use] GT 0,n_conj)
 IF n_conj GT 0 THEN BEGIN
     if keyword_set(beam_per_baseline) then begin
         uu[conj_i]=-uu[conj_i]

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -31,7 +31,7 @@ n_vis_arr=obs.nf_vis
 baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
   bi_use=bi_use,fi_use=fi_use,vis_inds_use=vis_inds_use,interp_flag=interp_flag,$
   dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,$
-  mask_mirror_indices=mask_mirror_indices
+  x_offset=x_offset,y_offset=y_offset,mask_mirror_indices=mask_mirror_indices
 
 ; Use indices of visibilities to grid during this call (i.e. specific freqs, time sets)
 ; to initialize output arrays

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -22,22 +22,19 @@ IF Tag_exist(obs,'alpha') THEN alpha=obs.alpha ELSE alpha=0.
 freq_bin_i=(*obs.baseline_info).fbin_i
 n_freq=Long(obs.n_freq)
 IF N_Elements(fi_use) EQ 0 THEN fi_use=where((*obs.baseline_info).freq_use)
+n_f_use=N_Elements(fi_use)
 freq_bin_i=freq_bin_i[fi_use]
 n_vis_arr=obs.nf_vis
 
 ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
 ; and the 2D derivatives for bilinear interpolation
 baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
-  bi_use=bi_use,fi_use=fi_use,interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
-  dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,mask_mirror_indices=mask_mirror_indices
+  bi_use=bi_use,fi_use=fi_use,vis_inds_use=vis_inds_use,interp_flag=interp_flag,$
+  dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,$
+  mask_mirror_indices=mask_mirror_indices
 
-n_b_use=N_Elements(bi_use)
-n_f_use=N_Elements(fi_use)
-
-; Calculate indices of visibilities to grid during this call (i.e. specific freqs, time sets)
-; and initialize output arrays
-vis_inds_use=matrix_multiply(fi_use,replicate(1L,n_b_use))+matrix_multiply(replicate(1L,n_f_use),bi_use)*n_freq
-IF vis_weight_switch THEN vis_weights=vis_weights[vis_inds_use]
+; Use indices of visibilities to grid during this call (i.e. specific freqs, time sets)
+; to initialize output arrays
 IF Keyword_Set(preserve_visibilities) THEN vis_arr_use=(*visibility_ptr)[vis_inds_use] ELSE BEGIN
     vis_arr_use=(Temporary(*visibility_ptr))[vis_inds_use] 
     Ptr_free,visibility_ptr

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -29,7 +29,7 @@ n_vis_arr=obs.nf_vis
 ; and the 2D derivatives for bilinear interpolation
 baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
   bi_use=bi_use,fi_use=fi_use,interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
-  dx1dy0_arr=dx1dy0_arr,mask_mirror_indicies=mask_mirror_indicies
+  dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,mask_mirror_indices=mask_mirror_indices
 
 n_b_use=N_Elements(bi_use)
 n_f_use=N_Elements(fi_use)

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -31,7 +31,8 @@ n_vis_arr=obs.nf_vis
 baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
   bi_use=bi_use,fi_use=fi_use,vis_inds_use=vis_inds_use,interp_flag=interp_flag,$
   dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,dx1dy0_arr=dx1dy0_arr,dx1dy1_arr=dx1dy1_arr,$
-  x_offset=x_offset,y_offset=y_offset,mask_mirror_indices=mask_mirror_indices
+  x_offset=x_offset,y_offset=y_offset,preserve_visibilities=preserve_visibilities,$
+  mask_mirror_indices=mask_mirror_indices
 
 ; Use indices of visibilities to grid during this call (i.e. specific freqs, time sets)
 ; to initialize output arrays

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -11,14 +11,8 @@ t0_0=Systime(1)
 heap_gc
 
 ; Extract information from the structures
-pol_names=obs.pol_names
 dimension=Long(obs.dimension)
 elements=Long(obs.elements)
-kbinsize=obs.kpix
-kx_span=kbinsize*Float(dimension) ;Units are # of wavelengths
-ky_span=kx_span
-min_baseline=obs.min_baseline
-max_baseline=obs.max_baseline
 double_precision=0
 IF Tag_Exist(obs, 'double_precision') THEN double_precision=obs.double_precision
 IF N_Elements(silent) EQ 0 THEN verbose=0 ELSE verbose=0>Round(1-silent)<1
@@ -31,27 +25,12 @@ IF N_Elements(fi_use) EQ 0 THEN fi_use=where((*obs.baseline_info).freq_use)
 freq_bin_i=freq_bin_i[fi_use]
 n_vis_arr=obs.nf_vis
 
-; Careful treatment to avoid overwriting the weights pointer
-vis_weight_switch=Ptr_valid(vis_weight_ptr)
-IF vis_weight_switch THEN BEGIN
-    IF Keyword_Set(preserve_visibilities) THEN vis_weights=*vis_weight_ptr ELSE BEGIN
-        vis_weights=Temporary(*vis_weight_ptr)
-        Ptr_free,vis_weight_ptr
-    ENDELSE
-ENDIF
+; For each unflagged baseline, get the minimum contributing pixel number for gridding 
+; and the 2D derivatives for bilinear interpolation
+baseline_grid_locations,obs,psf,params,xmin=xmin,ymin=ymin,vis_weight_ptr=vis_weight_ptr,$
+  bi_use=bi_use,fi_use=fi_use,interp_flag=interp_flag,dx0dy0_arr=dx0dy0_arr,dx0dy1_arr=dx0dy1_arr,$
+  dx1dy0_arr=dx1dy0_arr,mask_mirror_indicies=mask_mirror_indicies
 
-IF N_Elements(bi_use) EQ 0 THEN BEGIN
-    ; If the data is being gridded separatedly for the even/odd time samples, then force
-    ; flagging to be consistent across even/odd sets
-    IF vis_weight_switch THEN BEGIN
-        flag_test=Total(vis_weights>0,1)
-        bi_use=where((flag_test GT 0))
-    ENDIF ELSE BEGIN
-        b_info=(*obs.baseline_info)
-        tile_use=where(b_info.tile_use)+1
-        bi_use=array_match(b_info.tile_A,b_info.tile_B,value_match=tile_use)
-    ENDELSE
-ENDIF
 n_b_use=N_Elements(bi_use)
 n_f_use=N_Elements(fi_use)
 
@@ -89,11 +68,6 @@ beam_arr=*psf.beam_ptr
 weights_flag=Keyword_Set(weights)
 variance_flag=Keyword_Set(variance)
 uniform_flag=Keyword_Set(uniform_filter)
-uu=params.uu[bi_use]
-vv=params.vv[bi_use]
-ww=params.ww[bi_use]
-kx_arr=uu/kbinsize ;units in pixel/Hz
-ky_arr=vv/kbinsize
 
 nbaselines=obs.nbaselines
 n_samples=obs.n_time
@@ -105,6 +79,11 @@ bi_use_reduced=bi_use mod nbaselines
 if keyword_set(beam_per_baseline) then begin
     ; Initialization for gridding operation via a low-res beam kernel, calculated per
     ; baseline using offsets from image-space delays
+    uu=params.uu[bi_use]
+    vv=params.vv[bi_use]
+    ww=params.ww[bi_use]
+    x = (FINDGEN(dimension) - dimension/2.)*obs.kpix
+    y = (FINDGEN(dimension) - dimension/2.)*obs.kpix
     uv_grid_phase_only=1 ;w-terms have not been tested, thus they've been turned off for now
     psf_intermediate_res=(Ceil(Sqrt(psf_resolution)/2)*2.)<psf_resolution
     psf_image_dim=(*psf.image_info).psf_image_dim
@@ -131,79 +110,15 @@ IF Keyword_Set(mapfn_recalculate) THEN BEGIN
     map_fn=Ptrarr(dimension,elements)
 ENDIF ELSE map_flag=0
 
-; Flag baselines on their maximum and minimum extent in the frequency range
-dist_test=Sqrt((kx_arr)^2.+(ky_arr)^2.)*kbinsize
-dist_test_max=max((*obs.baseline_info).freq)*dist_test
-dist_test_min=min((*obs.baseline_info).freq)*dist_test
-flag_dist_baseline=where((dist_test_min LT min_baseline) $
-  OR (dist_test_max GT max_baseline),n_dist_flag)
-dist_test=0
-dist_test_min=0
-dist_test_max=0
-
-conj_i=where(ky_arr GT 0,n_conj)
-conj_flag=intarr(N_Elements(ky_arr)) 
+conj_i=where(params.vv GT 0,n_conj)
 IF n_conj GT 0 THEN BEGIN
-    conj_flag[conj_i]=1
-    kx_arr[conj_i]=-kx_arr[conj_i]
-    ky_arr[conj_i]=-ky_arr[conj_i]
-    uu[conj_i]=-uu[conj_i]
-    vv[conj_i]=-vv[conj_i]
-    ww[conj_i]=-ww[conj_i]
+    if keyword_set(beam_per_baseline) then begin
+        uu[conj_i]=-uu[conj_i]
+        vv[conj_i]=-vv[conj_i]
+        ww[conj_i]=-ww[conj_i]
+    endif
     vis_arr_use[*,conj_i]=Conj(vis_arr_use[*,conj_i])
     IF model_flag THEN model_use[*,conj_i]=Conj(model_use[*,conj_i])
-ENDIF
-; Center of baselines for x and y in units of pixels
-xcen=Float(frequency_array#Temporary(kx_arr))
-ycen=Float(frequency_array#Temporary(ky_arr))
-
-x = (FINDGEN(dimension) - dimension/2.)*obs.kpix
-y = (FINDGEN(dimension) - dimension/2.)*obs.kpix
-
-; Pixel number offet per baseline for each uv-box subset 
-x_offset=Fix(Floor((xcen-Floor(xcen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
-y_offset=Fix(Floor((ycen-Floor(ycen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int
-; Derivatives from pixel edge to baseline center for use in interpolation
-dx_arr = (xcen-Floor(xcen))*psf_resolution - Floor((xcen-Floor(xcen))*psf_resolution)
-dy_arr = (ycen-Floor(ycen))*psf_resolution - Floor((ycen-Floor(ycen))*psf_resolution)
-dx0dy0_arr = (1-dx_arr)*(1-dy_arr)
-dx0dy1_arr = (1-dx_arr)*dy_arr
-dx1dy0_arr = dx_arr*(1-dy_arr)
-dx1dy1_arr = Temporary(dx_arr) * Temporary(dy_arr)
-; The minimum pixel in the uv-grid (bottom left of the kernel) that each baseline contributes to
-xmin=Long(Floor(Temporary(xcen))+dimension/2-(psf_dim/2-1))
-ymin=Long(Floor(Temporary(ycen))+elements/2-(psf_dim/2-1))
-
-; Set the minimum pixel value of baselines which fall outside of the uv-grid to -1 to exclude them
-range_test_x_i=where((xmin LE 0) OR ((xmin+psf_dim-1) GE dimension-1),n_test_x)
-range_test_y_i=where((ymin LE 0) OR ((ymin+psf_dim-1) GE elements-1),n_test_y)
-IF n_test_x GT 0 THEN xmin[range_test_x_i]=(ymin[range_test_x_i]=-1)
-IF n_test_y GT 0 THEN xmin[range_test_y_i]=(ymin[range_test_y_i]=-1)
-
-IF n_dist_flag GT 0 THEN BEGIN
-    ; If baselines fall outside the desired min/max baseline range at all during the frequency range, 
-    ; then set their minimum pixel value to -1 to exlude them 
-    xmin[*,flag_dist_baseline]=-1
-    ymin[*,flag_dist_baseline]=-1
-ENDIF
-
-IF vis_weight_switch THEN BEGIN
-    ; If baselines are flagged via the weights, then set their minimum pixel value to -1 to exclude them
-    flag_i=where(vis_weights LE 0,n_flag)
-    vis_weights=0
-    IF n_flag GT 0 THEN BEGIN
-        xmin[flag_i]=-1
-        ymin[flag_i]=-1
-    ENDIF
-    flag_i=0
-ENDIF
-
-IF Keyword_Set(mask_mirror_indices) THEN BEGIN
-    ; Option to exlude v-axis mirrored baselines
-    IF n_conj GT 0 THEN BEGIN
-        xmin[*,conj_i]=-1
-        ymin[*,conj_i]=-1
-    ENDIF
 ENDIF
 
 IF max(xmin)<max(ymin) LT 0 THEN BEGIN

--- a/fhd_output/fft_filters/filter_uv_optimal.pro
+++ b/fhd_output/fft_filters/filter_uv_optimal.pro
@@ -9,14 +9,16 @@ IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 IF ~(Keyword_Set(obs) AND Keyword_Set(psf) AND Keyword_Set(params)) THEN BEGIN
     IF Keyword_Set(file_path_fhd) THEN BEGIN
         fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra) 
+        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,vis_weight_ptr=weights,$
+            file_path_fhd=file_path_fhd,_Extra=extra)
     ENDIF ELSE BEGIN
         IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv
         vis_count=weights/Min(weights[where(weights GT 0)])
     ENDELSE
 ENDIF ELSE BEGIN
     IF Keyword_Set(file_path_fhd) THEN fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,vis_weight_ptr=weights,$
+        file_path_fhd=file_path_fhd,_Extra=extra)
 ENDELSE
 
 

--- a/fhd_output/fft_filters/filter_uv_uniform.pro
+++ b/fhd_output/fft_filters/filter_uv_uniform.pro
@@ -10,14 +10,16 @@ IF Keyword_Set(return_name_only) THEN RETURN,image_uv
 IF ~(Keyword_Set(obs) AND Keyword_Set(psf) AND Keyword_Set(params)) THEN BEGIN
     IF Keyword_Set(file_path_fhd) THEN BEGIN
         fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra) 
+        IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,vis_weight_ptr=weights,$
+            file_path_fhd=file_path_fhd,_Extra=extra) 
     ENDIF ELSE BEGIN
         IF N_Elements(weights) NE N_Elements(image_uv) THEN RETURN,image_uv
         vis_count=weights/Min(weights[where(weights GT 0)])
     ENDELSE
 ENDIF ELSE BEGIN
     IF Keyword_Set(file_path_fhd) THEN fhd_save_io,status_str,vis_count,var='vis_count',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,file_path_fhd=file_path_fhd,_Extra=extra)
+    IF ~Keyword_Set(vis_count) THEN vis_count=visibility_count(obs,psf,params,vis_weight_ptr=weights,$
+        file_path_fhd=file_path_fhd,_Extra=extra)
 ENDELSE
 ;vis_count[where(vis_count)]=vis_count[where(vis_count)]>(Max(vis_count)/1000.)
 filter_use=weight_invert(vis_count,1.) ;should have psf.dim^2. factor, but that would divide out in the normalization later anyway


### PR DESCRIPTION
There was a lot of redundant code between `visibility_grid`,`visibility_degrid`, and `vis_count`. I've condensed the majority of the redundant code to a new file, `baseline_grid_locations`. This file returns information regarding the locations of the unflagged visibilities in units of pixels in a variety of different forms.

Each of the three original files accounted for flagging in a slightly different way, and I've recreated each of those. The only exception being that unsetting `fill_model_visibilities` during the model making process will emulate the flagging done for gridding with this new file -- arguably what we want to do anyways. In any case, `fill_model_visibilities` is currently hard set on anyways. 

The power spectra for a typical run are the same between the old branch and the new branch. The images, however, are different on extremely low levels (i.e. 10^-20), which makes me think I haven't fully replicated some float/double behaviour during image making. I will continue to investigate this, but I'd like to get this branch reviewed as fast as possible so that it can be ported to python via Joel in the next 2 weeks.