### PR TITLE
group_arr psf.id bug

### DIFF
--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -61,7 +61,6 @@ frequency_array=frequency_array[fi_use]
 complex_flag=psf.complex_flag
 psf_dim=psf.dim
 psf_resolution=psf.resolution
-group_arr=reform(psf.id[polarization,freq_bin_i[fi_use],bi_use])
 beam_arr=*psf.beam_ptr
 
 weights_flag=Keyword_Set(weights)
@@ -74,6 +73,8 @@ n_freq_use=N_Elements(frequency_array)
 psf_dim2=2*psf_dim
 psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
+; Restructure the psf ID such that the last dimension matches the visiblity array in order to use future index arrays
+group_arr=reform(rebin(reform(psf.id[polarization,freq_bin_i[fi_use],*]),n_f_use,nbaselines,n_samples), n_f_use,n_samples*nbaselines)
 
 if keyword_set(beam_per_baseline) then begin
     ; Initialization for gridding operation via a low-res beam kernel, calculated per


### PR DESCRIPTION
As mentioned in Slack:

> I think Joel may have found a bug, and I wanted to get your opinion.
> Line 64 of visibility_grid.pro finds the group identifier if there are multiple beams being used:
> group_arr=reform(psf.id[polarization,freq_bin_i[fi_use],bi_use])
> However, bi_use has the same dimensionality as the num of visiblities (4 million something), and psf.id has the dimensionality of x, x, 8128 . It doesn’t error, but I think the group_arr is set to the last value in the array if it exceeds 8128.
> I think maybe bi_use should be bi_use_reduced. I wanted to check with you though, because it seemed like this could have potential for IDL black magic.
> Maybe this hasn’t been an issue thus far because we generally use one beam. And maybe this explains why our dead dipole tests never really went anywhere.

I played around with a couple of iterations, and this was the fastest/most compact. Still looks a little clunky, so I'm open to suggestions. 