### PR TITLE
Multi-beam fixes

### DIFF
--- a/fhd_core/beam_modeling/beam_setup.pro
+++ b/fhd_core/beam_modeling/beam_setup.pro
@@ -182,6 +182,9 @@ FUNCTION beam_setup,obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_l
         ;Get the baseline index
         bi_use=Reform(rebin((ant_1_arr+1),ant_1_n,ant_2_n)*baseline_mod+$
           Rebin(Transpose(ant_2_arr+1),ant_1_n,ant_2_n),baseline_group_n)
+        bi_use2=Reform(rebin((ant_1_arr+1),ant_1_n,ant_2_n)+$
+          Rebin(Transpose(ant_2_arr+1),ant_1_n,ant_2_n)*baseline_mod,baseline_group_n)
+        bi_use = [bi_use, bi_use2]
         IF Max(bi_use) GT bi_max THEN bi_use=bi_use[where(bi_use LE bi_max)]
         bi_use_i=where(bi_hist0[bi_use],n_use)
         IF n_use GT 0 THEN bi_use=bi_use[bi_use_i]
@@ -189,7 +192,7 @@ FUNCTION beam_setup,obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_l
         ;use these indices to index the reverse indices of the original baseline index histogram
         bi_inds=ri_bi[ri_bi[bi_use]] 
         group_arr[pol_i,freq_i,bi_inds]=g_i
-               
+
         ;If the pols are equal, then only calculating one of the beams in the unique group matrix for efficiency.
         ;Set the redundant beam product to the one that is being calculated and redefine the element numbers.
         IF ant_pol1 EQ ant_pol2 THEN BEGIN

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -74,7 +74,7 @@ psf_dim2=2*psf_dim
 psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
 ; Restructure the psf ID such that the last dimension matches the visiblity array in order to use future index arrays
-group_arr=reform(rebin(reform(psf.id[polarization,freq_bin_i[fi_use],*]),n_f_use,nbaselines,n_samples), n_f_use,n_samples*nbaselines)
+group_arr=reform(rebin(reform(psf.id[polarization,freq_bin_i,*]),n_f_use,nbaselines,n_samples), n_f_use,n_samples*nbaselines)
 
 if keyword_set(beam_per_baseline) then begin
     ; Initialization for gridding operation via a low-res beam kernel, calculated per

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -25,6 +25,10 @@ n_f_use=N_Elements(fi_use)
 freq_bin_i=freq_bin_i[fi_use]
 n_vis_arr=obs.nf_vis
 
+IF keyword_set(beam_per_baseline) AND interp_flag THEN BEGIN
+    print, "WARNING: Cannot do beam per baseline and interpolation at the same time, turning off interpolation"
+    interp_flag = 0
+ENDIF
 
 ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
 ; and the 2D derivatives for bilinear interpolation


### PR DESCRIPTION
There were a few lingering bugs regarding the ID group array, which determines which baselines have the same beams. This is a rarely used option (at this stage).

This has been tested to give the proper IDs on two separate tests. There may remain some edge cases that I wasn't able to think of, but this should cover most cases with this option.

A warning was also added from the suggestion of Joel. 