### PR TITLE
antenna indices rewrite

### DIFF
--- a/fhd_core/fhd_main.pro
+++ b/fhd_core/fhd_main.pro
@@ -63,7 +63,7 @@ IF data_flag LE 0 THEN BEGIN
     ENDIF
     
     ;Note: explicitly reference dft_threshold here to remove it from EXTRA, which would be passed on to lower-level routines
-    obs=fhd_struct_init_obs(file_path_vis,hdr,params,n_pol=n_pol,dft_threshold=dft_threshold,_Extra=extra) 
+    obs=fhd_struct_init_obs(file_path_vis,hdr,params,layout,n_pol=n_pol,dft_threshold=dft_threshold,_Extra=extra) 
     n_pol=obs.n_pol
     n_freq=obs.n_freq
     

--- a/fhd_core/setup_metadata/fhd_struct_init_meta.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_meta.pro
@@ -1,4 +1,4 @@
-FUNCTION fhd_struct_init_meta,file_path_vis,hdr,params,lon=lon,lat=lat,alt=alt,n_tile=n_tile,$
+FUNCTION fhd_struct_init_meta,file_path_vis,hdr,params,layout,lon=lon,lat=lat,alt=alt,n_tile=n_tile,$
     zenra_in=zenra_in,zendec_in=zendec_in,obsra_in=obsra_in,obsdec_in=obsdec_in,phasera_in=phasera_in,phasedec_in=phasedec_in,$
     rephase_to_zenith=rephase_to_zenith,precess=precess,degpix=degpix,dimension=dimension,elements=elements,$
     obsx=obsx,obsy=obsy,instrument=instrument,mirror_X=mirror_X,mirror_Y=mirror_Y,no_rephase=no_rephase,$
@@ -82,7 +82,7 @@ ENDIF ELSE BEGIN
     hist_A1=histogram(tile_A1,min=1,max=n_tile,/binsize,reverse_ind=ria)
     hist_B1=histogram(tile_B1,min=1,max=n_tile,/binsize,reverse_ind=rib)
     hist_AB=hist_A1+hist_B1
-    tile_names=indgen(n_tile)+1
+    tile_names=layout.antenna_numbers
     tile_use=where(hist_AB,n_tile_exist,complement=missing_i,ncomplement=missing_n)+1
     tile_height=Fltarr(n_tile)
     tile_flag0=intarr(n_tile)

--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -134,9 +134,9 @@ if max(params.antenna1) GT n_tile then begin
     tile_B = params.antenna2
     for tile_i=0, n_tile-1 do begin
         inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna1),n_count)
-        if n_count GT 0 then tile_A[inds] = tile_i+1
+        if n_count GT 0 then tile_A[inds] = tile_i+1 else message, "antenna numbers in uvfits vis and ant hdus do not match"
         inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna2),n_count)
-        if n_count GT 0 then tile_B[inds] = tile_i+1
+        if n_count GT 0 then tile_B[inds] = tile_i+1 else message, "antenna numbers in uvfits vis and ant hdus do not match"
     endfor
     params.antenna1 = tile_A
     params.antenna2 = tile_B

--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -59,17 +59,13 @@ ENDIF ELSE BEGIN
     grid_info=Ptr_new()
 ENDELSE
 
-antenna_flag = 1
 IF Tag_exist(params, "antenna1") AND Tag_exist(params, "antenna2") THEN BEGIN
     ant1_arr = params.antenna1
     ant2_arr = params.antenna2
-    IF Max(ant1_arr) GT 0 AND Max(ant2_arr) GT 0 THEN BEGIN
-        tile_A = ant1_arr
-        tile_B = ant2_arr
-        n_tile=max(tile_A)>max(tile_B)
-        antenna_flag = 0
-    ENDIF
-ENDIF
+    tile_A = ant1_arr
+    tile_B = ant2_arr
+    antenna_flag=0 
+ENDIF ELSE antenna_flag = 1
 IF antenna_flag THEN BEGIN
     ;256 tile upper limit is hard-coded in CASA format
     ;these tile numbers have been verified to be correct
@@ -134,6 +130,20 @@ noise_arr=Ptr_new()
 
 meta=fhd_struct_init_meta(file_path_vis,hdr,params,degpix=degpix,dimension=dimension,elements=elements,$
     n_tile=n_tile,instrument=instrument,meta_data=meta_data,meta_hdr=meta_hdr,_Extra=extra)
+
+; If it appears that the params struct uses tile names instead of indices, then rewrite with indices
+if max(params.antenna1) GT n_tile then begin
+    tile_A = params.antenna1 - 1
+    tile_B = params.antenna2 - 1
+    for tile_i=0, n_tile-1 do begin
+        inds = where(meta.tile_names[tile_i] EQ (params.antenna1 - 1),n_count)
+        if n_count GT 0 then tile_A[inds] = tile_i+1
+        inds = where(meta.tile_names[tile_i] EQ (params.antenna2 - 1),n_count)
+        if n_count GT 0 then tile_B[inds] = tile_i+1
+    endfor
+    params.antenna1 = tile_A
+    params.antenna2 = tile_B
+endif
 
 IF N_Elements(meta_data) EQ 0 THEN meta_data=Ptr_new() ELSE meta_data=Ptr_new(meta_data)
 IF N_Elements(meta_hdr) EQ 0 THEN meta_hdr=Ptr_new() ELSE meta_hdr=Ptr_new(meta_hdr)

--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -134,9 +134,9 @@ if max(params.antenna1) GT n_tile then begin
     tile_B = params.antenna2
     for tile_i=0, n_tile-1 do begin
         inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna1),n_count)
-        if n_count GT 0 then tile_A[inds] = tile_i+1 else message, "antenna numbers in uvfits vis and ant hdus do not match"
+        if n_count GT 0 then tile_A[inds] = tile_i+1
         inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna2),n_count)
-        if n_count GT 0 then tile_B[inds] = tile_i+1 else message, "antenna numbers in uvfits vis and ant hdus do not match"
+        if n_count GT 0 then tile_B[inds] = tile_i+1
     endfor
     params.antenna1 = tile_A
     params.antenna2 = tile_B

--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -1,4 +1,4 @@
-FUNCTION fhd_struct_init_obs,file_path_vis,hdr,params, dimension=dimension, elements=elements, degpix=degpix, kbinsize=kbinsize, $
+FUNCTION fhd_struct_init_obs,file_path_vis,hdr,params,layout,dimension=dimension, elements=elements, degpix=degpix, kbinsize=kbinsize, $
     n_pol=n_pol,max_baseline=max_baseline,min_baseline=min_baseline,double_precision=double_precision,$
     FoV=FoV,rotate_uv=rotate_uv,scale_uv=scale_uv,mirror_X=mirror_X,mirror_Y=mirror_Y,$
     zenra=zenra,zendec=zendec,phasera=phasera,phasedec=phasedec,obsx=obsx,obsy=obsy,instrument=instrument,$
@@ -128,22 +128,22 @@ IF N_Elements(min_baseline) EQ 0 THEN min_baseline=Min(kr_arr[where(kr_arr)]) EL
 kx_arr=0 & ky_arr=0 & kr_arr=0 ;free memory
 noise_arr=Ptr_new()
 
-meta=fhd_struct_init_meta(file_path_vis,hdr,params,degpix=degpix,dimension=dimension,elements=elements,$
-    n_tile=n_tile,instrument=instrument,meta_data=meta_data,meta_hdr=meta_hdr,_Extra=extra)
-
 ; If it appears that the params struct uses tile names instead of indices, then rewrite with indices
 if max(params.antenna1) GT n_tile then begin
-    tile_A = params.antenna1 - 1
-    tile_B = params.antenna2 - 1
+    tile_A = params.antenna1
+    tile_B = params.antenna2
     for tile_i=0, n_tile-1 do begin
-        inds = where(meta.tile_names[tile_i] EQ (params.antenna1 - 1),n_count)
+        inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna1),n_count)
         if n_count GT 0 then tile_A[inds] = tile_i+1
-        inds = where(meta.tile_names[tile_i] EQ (params.antenna2 - 1),n_count)
+        inds = where(layout.antenna_numbers[tile_i] EQ (params.antenna2),n_count)
         if n_count GT 0 then tile_B[inds] = tile_i+1
     endfor
     params.antenna1 = tile_A
     params.antenna2 = tile_B
 endif
+
+meta=fhd_struct_init_meta(file_path_vis,hdr,params,layout,degpix=degpix,dimension=dimension,elements=elements,$
+    n_tile=n_tile,instrument=instrument,meta_data=meta_data,meta_hdr=meta_hdr,_Extra=extra)
 
 IF N_Elements(meta_data) EQ 0 THEN meta_data=Ptr_new() ELSE meta_data=Ptr_new(meta_data)
 IF N_Elements(meta_hdr) EQ 0 THEN meta_hdr=Ptr_new() ELSE meta_hdr=Ptr_new(meta_hdr)


### PR DESCRIPTION
Quick little fix for the pyuvdata antenna naming convention. I admit that it may not be the best fix....

For starters, there is an assumption that the number of tiles would be less than antenna names, and that the antenna names are numbers. These are both assumptions that could break. 

fixes #292