### PR TITLE
Remove nans for cal plotting residuals

### DIFF
--- a/fhd_output/calibration_plots/plot_cals.pro
+++ b/fhd_output/calibration_plots/plot_cals.pro
@@ -110,8 +110,8 @@ for file_i=0, page_num-1 do begin
             if page_num GT 1 then gains1_res=gains1_res[*,file_i*page_tile_max:(file_i+1)*page_tile_max<(size(gains1_res))[2]-1]
             gains1_orig=gains1_res+gains1
             gains1_res_abs=Abs(gains1_orig)-Abs(gains1)
-            max_amp_res = mean(abs([gains0_res_abs,gains1_res_abs])) + 3*stddev(abs([gains0_res_abs,gains1_res_abs]))
-        ENDIF ELSE max_amp_res = mean(abs(gains0_res_abs)) + 3*stddev(abs(gains0_res_abs))
+            max_amp_res = mean(abs([gains0_res_abs,gains1_res_abs]),/NAN) + 3*stddev(abs([gains0_res_abs,gains1_res_abs]),/NAN)
+        ENDIF ELSE max_amp_res = mean(abs(gains0_res_abs),/NAN) + 3*stddev(abs(gains0_res_abs),/NAN)
     
         ;plot amplitude residuals
         IF max_amp_res GT 0 THEN BEGIN

--- a/fhd_output/calibration_plots/plot_cals_sub.pro
+++ b/fhd_output/calibration_plots/plot_cals_sub.pro
@@ -29,8 +29,8 @@ ENDIF ELSE BEGIN
         ENDELSE
         
         IF (gain_type LE 5) OR Keyword_Set(real_vs_imaginary) THEN BEGIN
-            IF n_pol GT 1 THEN max_amp = mean(abs([gains_A[*,tile_use_i],gains_B[*,tile_use_i]])) + 5*stddev(abs([gains_A[*,tile_use_i],gains_B[*,tile_use_i]])) $
-                ELSE max_amp = Mean(abs(gains_A[*,tile_use_i])) + 5*stddev(abs(gains_A[*,tile_use_i]))
+            IF n_pol GT 1 THEN max_amp = mean(abs([gains_A[*,tile_use_i],gains_B[*,tile_use_i]]),/NAN) + 5*stddev(abs([gains_A[*,tile_use_i],gains_B[*,tile_use_i]]),/NAN) $
+                ELSE max_amp = Mean(abs(gains_A[*,tile_use_i]),/NAN) + 5*stddev(abs(gains_A[*,tile_use_i]),/NAN)
             amp_range=Floor(Alog10(max_amp))
             IF amp_range LT 0 THEN amp_digits=1. ELSE amp_digits=2.
             amp_test=max_amp/10.^(amp_range-amp_digits)


### PR DESCRIPTION
Untested. This should allow for the cal residual plots to be made even if there are nans in the gain solutions (i.e. flagged channels).