### PR TITLE
Diffuse options

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -366,17 +366,21 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Default*: 1 (100 Mb) <br />
   -*Turn off/on*: 0/1 (optionally set to bytes)<br />
 
+**diffuse_fft_window**: an array of two strings indicating the anti-aliasing window to be used before the FFT (first element) and after the FFT (second element) as defined by `spectral_window.pro` in the fhdps_utils repo. If a Tukey window is specified before the FFT, then the alpha parameter will be calculated to align with the primary lobe of the instrument. If a Tukey window is specified after the FFT, then the alpha parameter will be calculated to align with 50 wavelengths. <br />
+  -*Turn off/on*: 0/1 (which defaults to \['Tukey','Blackman-Harris'\]) <br />
+  -*Default*: 0 <br />
+
 **diffuse_model**: File path to the diffuse model sav file. <br />
-  -*Turn off/on*: 0/1 <br />
   -*Default*: not set <br />
   -*eor_wrapper_defaults*: 0 <br />
   -The .sav file should contain the following:<br />
   - MODEL_ARR = A healpix map with the diffuse model. Diffuse model has units Jy/pixel unless keyword diffuse_units_kelvin is set. The model can be an array of pixels, a pointer to an array of pixels, or an array of four pointers corresponding to I, Q, U, and V Stokes polarized maps. <br />
   - NSIDE = The corresponding NSIDE parameter of the healpix map.<br />
   - HPX_INDS = The corresponding healpix indices of the model_arr.<br />
+  - UNITS = The units of the map, either Jy/str or Kelvin.<br />
   - COORD_SYS = (Optional) 'galactic' or 'celestial'. Specifies the coordinate system of the healpix map. GSM is in galactic coordinates, for instance. If missing, defaults to equatorial.<br />
 
-**diffuse_units_kelvin**: defines the units of the diffuse model to be in units Kelvin. Used if either diffuse_model or diffuse_calibrate are set. <br />
+**diffuse_units_kelvin**: defines the units of the diffuse model to be in units Kelvin. If the units are specified as Kelvin in the `diffuse_model`, then this will be set. Used if either diffuse_model or diffuse_calibrate are set. <br />
   -*Turn off/on*: 0/1 <br />
   -*Default*: 0 <br />
 

--- a/fhd_core/HEALPix/healpix_interpolate.pro
+++ b/fhd_core/HEALPix/healpix_interpolate.pro
@@ -48,7 +48,7 @@ image_mask[Min(Floor(xv_hpx)):Max(Ceil(xv_hpx)),Min(Floor(yv_hpx)):Max(Ceil(yv_h
 
 x_frac=1.-(xv_hpx-Floor(xv_hpx))
 y_frac=1.-(yv_hpx-Floor(yv_hpx))
-IF Keyword_Set(from_kelvin) THEN pixel_area_cnv=convert_kelvin_jansky(1.,nside=nside,freq=obs.freq_center) $
+IF Keyword_Set(from_kelvin) THEN pixel_area_cnv=convert_kelvin_jansky(1.,degpix=obs.degpix,freq=obs.freq_center) $
     ELSE IF keyword_set(from_jy_per_sr) THEN pixel_area_cnv=(obs.degpix*!DtoR)^2. $ ; (steradian/new pixel)
         ELSE pixel_area_cnv=((obs.degpix*!DtoR)^2.)/(4.*!Pi/n_hpx) ; (steradian/new pixel)/(steradian/old pixel)
 

--- a/fhd_core/source_modeling/fhd_diffuse_model.pro
+++ b/fhd_core/source_modeling/fhd_diffuse_model.pro
@@ -103,7 +103,7 @@ IF Keyword_Set(uv_return) THEN BEGIN
             ; This allows for the maximum amount of diffuse emission (important if calibrating)
             ;  while taking advantage of the natural taper of the instrument.  
             pbr = primary_beam_radius(obs,psf,beam_threshold=.01)
-            frac_size = dimension/(pbr*2/obs.degpix)
+            frac_size = (pbr * 2 / obs.degpix) / dimension
         ENDIF ELSE frac_size = 1
         window_1d_dim = spectral_window(dimension, type = diffuse_fft_window[0], $
           fractional_size = frac_size, periodic=1)

--- a/fhd_core/source_modeling/fhd_diffuse_model.pro
+++ b/fhd_core/source_modeling/fhd_diffuse_model.pro
@@ -1,60 +1,52 @@
-FUNCTION fhd_diffuse_model,obs,jones,skymodel,model_filepath=model_filepath,uv_return=uv_return,$
+FUNCTION fhd_diffuse_model,obs,jones,skymodel,psf,model_filepath=model_filepath,uv_return=uv_return,$
     spectral_model_arr=spectral_model_arr,diffuse_units_kelvin=diffuse_units_kelvin, $
-    flatten_spectrum=flatten_spectrum,no_polarized_diffuse=no_polarized_diffuse,_Extra=extra
+    flatten_spectrum=flatten_spectrum,no_polarized_diffuse=no_polarized_diffuse,$
+    diffuse_fft_window=diffuse_fft_window,_Extra=extra
 
 dimension=obs.dimension
 elements=obs.elements
-astr=obs.astr
-degpix=obs.degpix
 n_pol=obs.n_pol
 n_spectral=obs.degrid_spectral_terms
 IF Keyword_Set(skymodel) THEN diffuse_spectral_index=skymodel.diffuse_spectral_index ELSE diffuse_spectral_index=0
-apply_astrometry, obs, x_arr=meshgrid(dimension,elements,1), y_arr=meshgrid(dimension,elements,2), ra_arr=ra_arr, dec_arr=dec_arr, /xy2ad
-radec_i=where(Finite(ra_arr))
 IF Keyword_Set(flatten_spectrum) THEN alpha_corr=obs.alpha ELSE alpha_corr=0.
-IF N_Elements(diffuse_units_kelvin) EQ 0 THEN diffuse_units_kelvin = 0
-IF Keyword_Set(diffuse_units_kelvin) THEN from_jy_per_sr = 0 ELSE from_jy_per_sr = 1
-
-;freq_use=where((*obs.baseline_info).freq_use,nf_use)
-;f_bin=(*obs.baseline_info).fbin_i
-;fb_use=Uniq(f_bin[freq_use])
-;nbin=N_Elements(fb_use)
-;freq_arr=(*obs.baseline_info).freq
-;alpha=obs.alpha
-;freq_norm=freq_arr^(-alpha)
-;;freq_norm/=Sqrt(Mean(freq_norm^2.))
-;freq_norm/=Mean(freq_norm) 
-;d_freq=Median(Float(deriv(freq_arr)))
-;
-;freq_norm=freq_norm[freq_use[fb_use]]
-;
-;freq_arr_use=freq_arr[freq_use[fb_use]]/1E6
-;fb_hist=histogram(f_bin[freq_use],min=0,bin=1)
-;nf_arr=fb_hist[f_bin[freq_use[fb_use]]]
 
 IF file_test(model_filepath) EQ 0 THEN RETURN,Ptrarr(n_pol)
-var_dummy=getvar_savefile(model_filepath,names=var_names)
-;save file must have one variable called 'hpx_inds', one called 'nside', and at least one other variable. If there are multiple other variables, it must be called 'model_arr'
-hpx_inds=getvar_savefile(model_filepath,'hpx_inds')
-nside=getvar_savefile(model_filepath,'nside')
-var_name_inds=where((StrLowCase(var_names) NE 'hpx_inds') AND (StrLowCase(var_names) NE 'nside'))
-var_names=var_names[var_name_inds]
-var_name_use=var_names[(where(StrLowCase(var_names) EQ 'model_arr',n_match))[0]>0] ;will pick 'model_arr' if present, or the first variable that is not 'hpx_inds' or 'nside'
-model_hpx_arr=getvar_savefile(model_filepath,var_name_use)
 
-model_spectra_i=where(StrLowCase(var_names) EQ 'model_spectral_arr',n_match)
-IF n_match GE 1 THEN diffuse_spectral_index=getvar_savefile(model_filepath,var_names[model_spectra_i])
-IF n_spectral LE 0 THEN undefine_fhd,diffuse_spectral_index
+; Get variables from the savefile. Must have one variable called 'hpx_inds', one called 'nside', 
+;  and one data variable. If there are multiple other variables, data variable must be 'model_arr'
+var_dummy = getvar_savefile(model_filepath, names = var_names)
+hpx_inds = getvar_savefile(model_filepath, 'hpx_inds')
+nside = getvar_savefile(model_filepath, 'nside')
+var_name_inds = where((StrLowCase(var_names) NE 'hpx_inds') AND (StrLowCase(var_names) NE 'nside'))
+var_names = var_names[var_name_inds]
+; Will pick 'model_arr' if present, or the first variable that is not 'hpx_inds' or 'nside'
+var_name_use = var_names[(where(StrLowCase(var_names) EQ 'model_arr',n_match))[0]>0]
+model_hpx_arr = getvar_savefile(model_filepath, var_name_use)
 
-coord_use=where(StrLowCase(var_names) EQ 'coord_sys',m_match) ;will pick 'coord_sys' if present
-IF m_match EQ 0 THEN coord_use = 'celestial' ELSE coord_use=getvar_savefile(model_filepath,'coord_sys')    ; Assume celestial if not defined otherwise
+; Get spectral information.
+model_spectra_i = where(StrLowCase(var_names) EQ 'model_spectral_arr',n_match)
+IF n_match GE 1 THEN diffuse_spectral_index = getvar_savefile(model_filepath, var_names[model_spectra_i])
+IF n_spectral LE 0 THEN undefine_fhd, diffuse_spectral_index
+
+; Get coordinate system if present. Assume celestial if not defined otherwise. 
+coord_use = where(StrLowCase(var_names) EQ 'coord_sys',m_match)
+IF m_match EQ 0 THEN coord_use = 'celestial' ELSE coord_use = getvar_savefile(model_filepath, 'coord_sys')
+
+; Get units if present. Assume Jy/str if not defined otherwise.
+units_use = where(StrLowCase(var_names) EQ 'units',m_match)
+IF m_match EQ 0 THEN units_use = 'Jy/str' ELSE units_use=getvar_savefile(model_filepath, 'units')
+if STRMATCH(units_use, 'kelvin', /FOLD_CASE) then diffuse_units_kelvin=1
+IF N_Elements(diffuse_units_kelvin) EQ 0 THEN diffuse_units_kelvin = 0
+IF Keyword_Set(diffuse_units_kelvin) THEN from_jy_per_sr = 0 ELSE from_jy_per_sr = 1
 
 IF size(diffuse_spectral_index,/type) EQ 10 THEN BEGIN ;check if pointer type
     ;need to write this!
     print,"A spectral index is defined in the saved diffuse model, but this is not yet supported!"
 ENDIF ;case of specifying a single scalar to be applied to the entire diffuse model is treated AFTER building the model in instrumental polarization
 
-model_stokes_arr=healpix_interpolate(model_hpx_arr,obs,nside=nside,hpx_inds=hpx_inds,from_jy_per_sr=from_jy_per_sr,from_kelvin=diffuse_units_kelvin,coord_sys=coord_use)
+model_stokes_arr=healpix_interpolate(model_hpx_arr,obs,nside=nside,hpx_inds=hpx_inds,$
+  from_jy_per_sr=from_jy_per_sr,from_kelvin=diffuse_units_kelvin,coord_sys=coord_use)
+
 IF size(model_stokes_arr,/type) EQ 10 THEN BEGIN
     np_hpx=Total(Ptr_valid(model_hpx_arr))
     IF Keyword_Set(no_polarized_diffuse) THEN np_hpx=1
@@ -92,13 +84,59 @@ IF (size(diffuse_spectral_index,/type) GE 1) AND (size(diffuse_spectral_index,/t
 ENDIF
 
 IF Keyword_Set(uv_return) THEN BEGIN
+
+    ; Option to apply fft filters to the image before/after the FFT to reduce aliasing
+    IF keyword_set(diffuse_fft_window) THEN BEGIN
+
+        ; Default to the Tukey window pre-FFT and Blackman-Harris window post-FFT
+        IF size(diffuse_fft_window,/type) NE 7 THEN BEGIN
+           diffuse_fft_window = ['Tukey','Blackman-Harris']
+        ENDIF ELSE BEGIN
+           IF N_elements(diffuse_fft_window) NE 2 THEN BEGIN
+               diffuse_fft_window = [diffuse_fft_window, diffuse_fft_window]
+           ENDIF
+        ENDELSE
+
+        ; Calculate pre-FFT window
+        IF diffuse_fft_window[0] EQ 'Tukey' THEN BEGIN
+            ; Calculate size of Tukey window to begin taper at the primary lobe null.
+            ; This allows for the maximum amount of diffuse emission (important if calibrating)
+            ;  while taking advantage of the natural taper of the instrument.  
+            pbr = primary_beam_radius(obs,psf,beam_threshold=.01)
+            frac_size = dimension/(pbr*2/obs.degpix)
+        ENDIF ELSE frac_size = 1
+        window_1d_dim = spectral_window(dimension, type = diffuse_fft_window[0], $
+          fractional_size = frac_size, periodic=1)
+        window_1d_ele = spectral_window(elements, type = diffuse_fft_window[0], $
+          fractional_size = frac_size, periodic=1)
+        window_2d_pre = window_1d_dim # transpose(window_1d_ele)
+
+       ; Calculate post-FFT window
+       IF diffuse_fft_window[1] EQ 'Tukey' THEN BEGIN
+           ; Estimate that most contributions past 50 wavelengths are artifacts (Byrne et al 2022)
+           frac_size = ((50. / obs.kpix) * 2) / dimension
+       ENDIF ELSE frac_size=1
+       window_1d_dim = spectral_window(dimension, type = diffuse_fft_window[1], $
+         fractional_size = frac_size, periodic=1)
+       window_1d_ele = spectral_window(elements, type = diffuse_fft_window[1], $
+         fractional_size = frac_size, periodic=1)
+       window_2d_post = window_1d_dim # transpose(window_1d_ele)
+
+    ENDIF
+
     model_uv_arr=Ptrarr(n_pol,/allocate)
     FOR pol_i=0,n_pol-1 DO BEGIN
-        model_uv=fft_shift(FFT(fft_shift(*model_arr[pol_i]),/inverse))
+        ; Apply filters before/after FFT if specified, otherwise calculate the unwindowed FFT  
+        IF keyword_set(diffuse_fft_window) THEN BEGIN
+            model_uv = fft_shift(FFT(fft_shift(*model_arr[pol_i]*window_2d_pre),/inverse))
+            model_uv = abs(model_uv)*window_2d_post*exp(Complex(0,1)*atan(model_uv,/phase))
+        ENDIF ELSE model_uv = fft_shift(FFT(fft_shift(*model_arr[pol_i]),/inverse))
         *model_uv_arr[pol_i]=model_uv
     ENDFOR
+
     Ptr_free,model_arr
-    RETURN,model_uv_arr 
+    RETURN,model_uv_arr
 ENDIF ELSE RETURN,model_arr
+
 END
 

--- a/fhd_core/source_modeling/vis_source_model.pro
+++ b/fhd_core/source_modeling/vis_source_model.pro
@@ -121,7 +121,7 @@ undefine_fhd,gal_model_uv,gal_spectral_model_uv
 IF Keyword_Set(diffuse_filepath) THEN BEGIN
     IF file_test(diffuse_filepath) EQ 0 THEN diffuse_filepath=(file_search(diffuse_filepath+'*'))[0]
     print,"Reading diffuse model file: "+diffuse_filepath 
-    diffuse_model_uv=fhd_diffuse_model(obs,jones,skymodel,spectral_model_arr=diffuse_spectral_model_uv,/uv_return,model_filepath=diffuse_filepath,_Extra=extra)
+    diffuse_model_uv=fhd_diffuse_model(obs,jones,skymodel,psf,spectral_model_arr=diffuse_spectral_model_uv,/uv_return,model_filepath=diffuse_filepath,_Extra=extra)
     IF Max(Ptr_valid(diffuse_model_uv)) EQ 0 THEN print,"Error reading or building diffuse model. Null pointer returned!"
 ENDIF
 IF Min(Ptr_valid(diffuse_model_uv)) GT 0 THEN FOR pol_i=0,n_pol-1 DO *model_uv_arr[pol_i]+=*diffuse_model_uv[pol_i];*uv_mask_use


### PR DESCRIPTION
In order to reduce aliasing when FFTing the diffuse map, I've added options for anti-aliasing windows before and after the FFT. I also found a small error with reading in Kelvin maps, which I think made it really difficult to compare Jy/str maps with Kelvin maps.

----Bug fix

When calculating the pixel area, the nside of the Healpix map was used instead of the pixel size of the flat, output map. Since the calculation is used to generate an output Jy/pixel map, the pixel area needs to be the output size. This doesn't affect Jy/str maps. This was in `healpix_interpolate.pro` which doesn't seem to be used anywhere else, so I think it's safe to change it there.

----Diffuse options

This gives the user the option to play with a variety of different spectral windows. However, I've found the following to be the best balance between using the majority of the diffuse map whilst reducing systematics. If more of the diffuse map is removed, then the calibration starts to deteriorate. 

Pre-FFT: Tukey window, where the alpha is calculated to align with the primary lobe. This allows the most instrumentally sensitive area of the diffuse map to remain to maximise calibration ability while still having a taper. Specifically, the taper begins at 1% beam level.
Post-FFT: A Blackman-Harris window. This keeps most everything under 50 wavelengths. I've also put in another Tukey option that tapers after 50 wavelengths (for the more conservative types).