### PR TITLE
Gaussian model update

### DIFF
--- a/fhd_core/source_modeling/source_dft_multi.pro
+++ b/fhd_core/source_modeling/source_dft_multi.pro
@@ -39,7 +39,9 @@ n_source=N_Elements(source_array)
 
 frequency=obs.freq_center
 freq_ref=Mean(source_array.freq)
-freq_ratio=Abs(Alog10(freq_ref/frequency)) ;it often happens that one is in Hz and the other in MHz. Assuming no one will ever want to extrapolate more than two orders of magnitude, correct any huge mismatch
+;it often happens that one is in Hz and the other in MHz. Assuming no one will ever want to 
+; extrapolate more than two orders of magnitude, correct any huge mismatch
+freq_ratio=Abs(Alog10(freq_ref/frequency))
 IF freq_ratio GT 2 THEN freq_scale=10.^(Round(Alog10(freq_ref/frequency)/3.)*3.) ELSE freq_scale=1.
 frequency_use=frequency*freq_scale
 
@@ -51,77 +53,43 @@ ENDFOR
 
 IF keyword_set(gaussian_source_models) then begin
   if tag_exist(source_array, 'shape') then begin
-    gaussian_ra=make_array(n_elements(source_array),/double)
-    gaussian_dec=make_array(n_elements(source_array),/double)
-    gaussian_rot=make_array(n_elements(source_array),/double)
-    for source_ind=0,n_elements(source_array)-1 do begin
-      if tag_exist(source_array[source_ind], 'shape') then begin
-        ;Convert from FWHM in arcsec to stddev in deg
-        gaussian_ra[source_ind]=source_array[source_ind].shape.x/(7200*sqrt(2*alog(2)))
-        gaussian_dec[source_ind]=source_array[source_ind].shape.y/(7200*sqrt(2*alog(2)))
-        ;Convert from deg to rad
-        gaussian_rot[source_ind]=source_array[source_ind].shape.angle*!Pi/180.
-      endif else begin
-        gaussian_ra[source_ind]=0
-        gaussian_dec[source_ind]=0
-        gaussian_rot[source_ind]=0
-      endelse
-    endfor
-    inds_gauss=where(gaussian_ra,n_gauss_params,complement=inds_point)
-    if n_gauss_params eq 0 then begin
-      print, 'Catalog does not contain Gaussian shape parameters. Unsetting keyword gaussian_source_models.'
-      undefine, gaussian_source_models
-    endif else begin
+    gauss_test = ceil(0>(source_array.shape.x + source_array.shape.y)<1)
+    gauss_inds = where(gauss_test GT 0,n_gauss)
+  endif else n_gauss=0
 
-      ;Gaussian source model major and minor axes RA DEC
-      ;           _ a_2,d_2
-      ;          / \
-      ; a_3,d_3 |   | a_1,d_1
-      ;          \_/
-      ;   a_4,d_4
-      ;
-      ;Convert from deg to pixels
-      ;Assumption: the RA/DEC of the gaussian can be approximated in a xy coord system where RA->x and DEC->y. DEC translates
-      ;well to xy coords, but RA does not, especially near celestial poles.
-      gaussian_ra_angular = acos(cos(gaussian_ra*!Dpi/180)/cos(source_array.dec*!Dpi/180)^2 - tan(source_array.dec*!Dpi/180)^2) * 180/!Dpi
-      gaussian_ra_vals = [[source_array.ra+.5*gaussian_ra_angular*cos(gaussian_rot)], [source_array.ra-.5*gaussian_dec*sin(gaussian_rot)], $
-        [source_array.ra-.5*gaussian_ra_angular*cos(gaussian_rot)], [source_array.ra+.5*gaussian_dec*sin(gaussian_rot)]]
-      gaussian_dec_vals = [[source_array.dec+.5*gaussian_ra_angular*sin(gaussian_rot)], [source_array.dec+.5*gaussian_dec*cos(gaussian_rot)], $
-        [source_array.dec-.5*gaussian_ra_angular*sin(gaussian_rot)], [source_array.dec-.5*gaussian_dec*cos(gaussian_rot)]]
-      undefine, gaussian_ra, gaussian_ra_angular, gaussian_dec
+  if n_gauss GT 0 then begin
+      ;Convert from FWHM in arcsec to stddev in deg
+      gaussian_ra=double(source_array[gauss_inds].shape.x)/(7200*sqrt(2*alog(2)))
+      gaussian_dec=double(source_array[gauss_inds].shape.y)/(7200*sqrt(2*alog(2)))
+      ;Convert from deg to rad
+      gaussian_rot=double(source_array[gauss_inds].shape.angle)*!DPi/180.
 
-      ;Curved sky gaussian widths in pixel coords
-      apply_astrometry, obs, x_arr=gaussian_x_vals, y_arr=gaussian_y_vals, ra_arr=gaussian_ra_vals, dec_arr=gaussian_dec_vals, /ad2xy
-      gaussian_x = sqrt((gaussian_x_vals[*,0]-gaussian_x_vals[*,2])^2+(gaussian_y_vals[*,0]-gaussian_y_vals[*,2])^2)
-      gaussian_y = sqrt((gaussian_x_vals[*,1]-gaussian_x_vals[*,3])^2+(gaussian_y_vals[*,1]-gaussian_y_vals[*,3])^2)
+      ;Compression due to flat sky approximation of curved sky, see J Cook et al. 2022
+      Eq2Hor,source_array[gauss_inds].ra,source_array[gauss_inds].dec, obs.JD0, gauss_alt, gauss_az, nutate=1,precess=1,$
+        aberration=0, refract=0, lon=obs.lon, alt=obs.alt, lat=obs.lat
+      gaussian_ra_corr = sqrt( sin(gaussian_rot)^2 + cos(gaussian_rot)^2 * sin((90.-gauss_az) * !DPi/180.)^2 )
+      gaussian_dec_corr = sqrt( cos(gaussian_rot)^2 + sin(gaussian_rot)^2 * cos((90.-gauss_az) * !DPi/180.)^2 )
 
-      ;Flat sky gaussian widths in pixel coords
-      flat_sky_gaussian_x = sqrt((gaussian_ra_vals[*,0]-gaussian_ra_vals[*,2])^2+(gaussian_dec_vals[*,0]-gaussian_dec_vals[*,2])^2)/obs.degpix
-      flat_sky_gaussian_y = sqrt((gaussian_ra_vals[*,1]-gaussian_ra_vals[*,3])^2+(gaussian_dec_vals[*,1]-gaussian_dec_vals[*,3])^2)/obs.degpix
-      undefine, gaussian_ra_vals, gaussian_dec_vals    
+      ;Calculate the x,y pixel coordinates of the gaussian sources
+      apply_astrometry, obs, x_arr=gaussian_x_vals, y_arr=gaussian_y_vals, ra_arr=[[obs.obsra-0.5*gaussian_ra], $
+        [obs.obsra+0.5*gaussian_ra]], dec_arr=[[obs.obsdec-0.5*gaussian_dec],[obs.obsdec+0.5*gaussian_dec]], /ad2xy
+      gaussian_x = (gaussian_x_vals[*,1]-gaussian_x_vals[*,0]) / gaussian_ra_corr
+      gaussian_y = (gaussian_y_vals[*,1]-gaussian_y_vals[*,0]) / gaussian_dec_corr
 
-      ;Projection effect on total integrated flux *in uv-space only*
-      flux_factor = (gaussian_x*gaussian_y)/(flat_sky_gaussian_x*flat_sky_gaussian_y)
-      FOR pol_i=0,n_pol-1 DO BEGIN
-          source_array_use[inds_gauss].flux.(pol_i)*=flux_factor[inds_gauss]
-      ENDFOR
-      gaussian_x[inds_point]=0
-      gaussian_y[inds_point]=0
-      undefine, flux_factor, flat_sky_gaussian_x, flat_sky_gaussian_y
+      ;Flux is affected by the compression
+      for pol_i=0, n_pol-1 do source_array_use[gauss_inds].flux.(pol_i) *= (gaussian_ra_corr * gaussian_dec_corr)
+
+      ; Create internal structure of gaussian source parametersto pass into dft subroutines
+      gaussian_source_models = {gauss_inds:gauss_inds, gaussian_x:gaussian_x, gaussian_y:gaussian_y, gaussian_rot:gaussian_rot}
 
     endelse
   endif else begin
     print, 'Catalog does not contain Gaussian shape parameters. Unsetting keyword gaussian_source_models.'
     undefine, gaussian_source_models
+    gauss_test = INTARR(n_source)
   endelse
-ENDIF
+ENDIF ELSE gauss_test = INTARR(n_source)
 
-IF ~keyword_set(gaussian_source_models) THEN BEGIN
-    ;Set all gaussian params to be 0
-    gaussian_x=make_array(n_elements(source_array),/double)
-    gaussian_y=make_array(n_elements(source_array),/double)
-    gaussian_rot=make_array(n_elements(source_array),/double)
-ENDIF
 
 IF Keyword_Set(n_spectral) THEN BEGIN
 ;obs.degrid_info is set up in fhd_struct_init_obs. It is turned on by setting the keyword degrid_nfreq_avg
@@ -137,13 +105,12 @@ IF Keyword_Set(n_spectral) THEN BEGIN
     IF Keyword_Set(dft_threshold) THEN BEGIN
         model_uv_arr=Ptrarr(n_pol,n_spectral+1)
         edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
-            gaussian_x OR gaussian_y,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+            gauss_test, n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
                 conserve_memory=conserve_memory,silent=silent,inds_use=edge_i,double_precision=double_precision,$
-                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x[edge_i], gaussian_y=gaussian_y[edge_i], $
-                gaussian_rot=gaussian_rot[edge_i])
+                gaussian_source_models=gaussian_source_models)
             FOR pol_i=0,n_pol-1 DO BEGIN
                 FOR s_i=0L,n_spectral DO BEGIN ;no "-1" for second loop!
                     single_uv=Complexarr(dimension,elements)
@@ -170,8 +137,7 @@ IF Keyword_Set(n_spectral) THEN BEGIN
         IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
         model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
             conserve_memory=conserve_memory,silent=silent,double_precision=double_precision,$
-            gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x, gaussian_y=gaussian_y, $
-            gaussian_rot=gaussian_rot)
+            gaussian_source_models=gaussian_source_models)
         model_uv_arr=Ptrarr(n_pol,n_spectral+1)
         FOR pol_i=0,n_pol-1 DO BEGIN
             FOR s_i=0L,n_spectral DO BEGIN ;no "-1" for second loop!
@@ -204,13 +170,12 @@ ENDIF ELSE BEGIN
     IF Keyword_Set(dft_threshold) THEN BEGIN
         model_uv_arr=Ptrarr(n_pol)
         edge_i = where((x_vec LT dft_edge_pix) OR (y_vec LT dft_edge_pix) OR (dimension-x_vec LT dft_edge_pix) OR (elements-y_vec LT dft_edge_pix) OR $
-            gaussian_x OR gaussian_y,n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
+            gauss_test, n_edge_pix, complement=center_pix_i, ncomplement=n_center_pix)
         IF n_edge_pix GT 0 THEN BEGIN
             IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
             model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
                 conserve_memory=conserve_memory,silent=silent,inds_use=edge_i,double_precision=double_precision,$
-                gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x[edge_i], gaussian_y=gaussian_y[edge_i], $
-                gaussian_rot=gaussian_rot[edge_i])
+                gaussian_source_models=gaussian_source_models)
             FOR pol_i=0,n_pol-1 DO BEGIN
                 single_uv=Complexarr(dimension,elements)
                 single_uv[uv_i_use]=*model_uv_vals[pol_i] 
@@ -236,8 +201,7 @@ ENDIF ELSE BEGIN
         IF N_Elements(conserve_memory) EQ 0 THEN conserve_memory=1
         model_uv_vals=source_dft(x_vec,y_vec,xvals,yvals,dimension=dimension,elements=elements,flux=flux_arr,$
             silent=silent,conserve_memory=conserve_memory,double_precision=double_precision,$
-            gaussian_source_models=gaussian_source_models, gaussian_x=gaussian_x, gaussian_y=gaussian_y, $
-            gaussian_rot=gaussian_rot)
+            gaussian_source_models=gaussian_source_models)
         FOR pol_i=0,n_pol-1 DO (*model_uv_full[pol_i])[uv_i_use]+=*model_uv_vals[pol_i]
         undefine_fhd,model_uv_vals,flux_arr
     ENDELSE

--- a/fhd_utils/FFT/source_dft.pro
+++ b/fhd_utils/FFT/source_dft.pro
@@ -1,7 +1,6 @@
 FUNCTION source_dft,x_loc,y_loc,xvals,yvals,dimension=dimension,elements=elements,flux=flux,$
     silent=silent,conserve_memory=conserve_memory,inds_use=inds_use,double_precision=double_precision, $
-    gaussian_source_models = gaussian_source_models, gaussian_x = gaussian_x, gaussian_y = gaussian_y, $
-    gaussian_rot = gaussian_rot
+    gaussian_source_models = gaussian_source_models
 
 fft_norm=1.
 icomp = Complex(0,1)
@@ -47,148 +46,163 @@ x_use=x_loc_use-dimension/2.
 y_use=y_loc_use-elements/2.
 x_use*=(2.*Pi/dimension)
 y_use*=(2.*Pi/dimension)
-if n_elements(gaussian_x) gt 0 then gauss_x_use=gaussian_x*(2.*Pi/dimension)
-if n_elements(gaussian_y) gt 0 then gauss_y_use=gaussian_y*(2.*Pi/dimension)
-if n_elements(gaussian_rot) gt 0 then begin
-    if total(abs(gaussian_rot)) EQ 0 then undefine, gaussian_rot
+if keyword_set(gaussian_source_models) then begin
+    ; gauss_inds_use is the subset of indices in inds_use that are gaussian sources
+    ; gauss_inds_dft is the subset of indices in the input gaussian_source_models structure that are currently being dft'd
+    match, inds_use, gaussian_source_models.gauss_inds, gauss_inds_use, gauss_inds_dft
+    n_gauss = N_elements(gauss_inds_use)
+    ; Define gaussian parameters for only the sources in this inds_use set that are gaussian
+    gauss_x_use2=(gaussian_source_models.gaussian_x[gauss_inds_dft]*(2.*Pi/dimension))^2
+    gauss_y_use2=(gaussian_source_models.gaussian_y[gauss_inds_dft]*(2.*Pi/dimension))^2
+    gaussian_rot=gaussian_source_models.gaussian_rot[gauss_inds_dft]
+    xvals2 = xvals*xvals
+    yvals2 = yvals*yvals
 endif
 
 element_check=Long64(N_Elements(xvals))*Long64(N_Elements(x_use))
 
-IF size(flux_use,/type) EQ 10 THEN BEGIN ;check if pointer type. This allows the same locations to be used for multiple sets of fluxes
+; Check if pointer type. This allows the same locations to be used for multiple sets of fluxes
+IF size(flux_use,/type) EQ 10 THEN BEGIN 
     fbin_use=where(Ptr_valid(flux_use),n_fbin)
     source_uv_vals=Ptrarr(size(flux_use,/dimension))
     IF size(*flux_use[0],/type) GE 6 THEN complex_flag=1 ELSE complex_flag=0
     FOR fbin_i=0L,n_fbin-1 DO source_uv_vals[fbin_use[fbin_i]]=Ptr_new(Complexarr(size(xvals,/dimension)))
+ENDIF
 
-    ;*****Start memory-managed DFT
-    ;If the max memory is less than the estimated memory needed to DFT all sources at once, then break the DFT into chunks
-    IF Keyword_Set(conserve_memory) AND (element_check GT mem_thresh) THEN BEGIN
+IF Keyword_Set(conserve_memory) AND (element_check GT mem_thresh) THEN BEGIN
+    ; DFT with memory management
+    ; If the max memory is less than the estimated memory needed to DFT all sources at once, then break the DFT into chunks
 
-        memory_bins=Ceil(element_check/mem_thresh) ;Estimate number of memory bins needed to maintain memory threshold
+    ; Using gaussian sources requires more more memory
+    if keyword_set(gaussian_source_models) then extra_factor=12 else extra_factor = 8
+    ; Estimate number of memory bins needed to maintain memory threshold
+    memory_bins=Ceil(element_check*extra_factor/mem_thresh) 
 
-        n0=N_Elements(x_use) ;Number of sources in primary beam to be DFTd
-        sources_per_bin=Round(n0/memory_bins)
-        binsize=Lonarr(memory_bins)+sources_per_bin ;Array of number of sources to DFT per bin
+    n0=N_Elements(x_use) ;Number of sources in primary beam to be DFTd
+    sources_per_bin=Round(n0/memory_bins)
+    binsize=Lonarr(memory_bins)+sources_per_bin ;Array of number of sources to DFT per bin
 
-        ;***Start special case of memory bins not being able to hold needed binsize for all DFTs
-        if memory_bins*sources_per_bin LT n0 then begin
-            unbinned_sources=n0-Total(binsize) ;Number of leftover sources that can't held currently
-            num_more_bins=Ceil(unbinned_sources/sources_per_bin) ;Number of bins that need to be added to hold all sources at required binsize
-            memory_bins+=num_more_bins ;Recalculate number of bins necessary
-            binsize=Lonarr(memory_bins)+sources_per_bin ;Recalculate binsize given new memory bins
-        endif
-        ;***End special case
+    ;Special case of memory bins not being able to hold needed binsize for all DFTs
+    if memory_bins*sources_per_bin LT n0 then begin
+        unbinned_sources=n0-Total(binsize) ;Number of leftover sources that can't held currently
+        num_more_bins=Ceil(unbinned_sources/sources_per_bin) ;Number of bins that need to be added to hold all sources at required binsize
+        memory_bins+=num_more_bins ;Recalculate number of bins necessary
+        binsize=Lonarr(memory_bins)+sources_per_bin ;Recalculate binsize given new memory bins
+    endif
 
-        ;Make the last bin forces number of sources distributed throughout bins equals the total num of sources.
-        binsize[memory_bins-1]-=Total(binsize)-n0
-        bin_start=[0,Total(binsize,/cumulative)]
-        FOR bin_i=0L,memory_bins-1 DO BEGIN
-            inds=lindgen(binsize[bin_i])+bin_start[bin_i]
-            phase=matrix_multiply(xvals,x_use[inds])+matrix_multiply(yvals,y_use[inds])
-            cos_term=Cos(phase)
-            sin_term=Sin(Temporary(phase))
-            IF keyword_set(gaussian_source_models) THEN BEGIN
-              if n_elements(gaussian_rot) gt 0 then begin
-                source_envelope = exp(-1./2 * $
-                  (matrix_multiply(xvals^2., gauss_x_use[inds]^2.*Cos(gaussian_rot[inds])^2.+gauss_y_use[inds]^2.*Sin(gaussian_rot[inds])^2.) $
-                  + matrix_multiply(yvals^2., gauss_x_use[inds]^2.*Sin(gaussian_rot[inds])^2.+gauss_y_use[inds]^2.*Cos(gaussian_rot[inds])^2.)) $
-                  + matrix_multiply(xvals*yvals, (gauss_y_use[inds]^2.-gauss_x_use[inds]^2.)*Cos(gaussian_rot[inds])*Sin(gaussian_rot[inds])))
-              endif else begin
-                source_envelope = exp(-1./2*(matrix_multiply(xvals^2., gauss_x_use[inds]^2.)+matrix_multiply(yvals^2., gauss_y_use[inds]^2.)))
-              endelse
-              cos_term *= source_envelope
-              sin_term *= source_envelope
-            ENDIF
+    ;Make the last bin forces number of sources distributed throughout bins equals the total num of sources.
+    binsize[memory_bins-1]-=Total(binsize)-n0
+    bin_start=[0,Total(binsize,/cumulative)]
+
+    FOR bin_i=0L,memory_bins-1 DO BEGIN
+        inds=lindgen(binsize[bin_i])+bin_start[bin_i]
+        ; Calculate sin and cosine of exponential in DFT (faster than a direct exp)
+        phase=matrix_multiply(x_use[inds],xvals) + matrix_multiply(y_use[inds],yvals)
+        cos_term=Cos(phase)
+        sin_term=Sin(Temporary(phase))
+
+        IF keyword_set(gaussian_source_models) THEN BEGIN
+            ; suba is the subset of indices in gauss_inds_use that are in this memory chunk loop
+            ; subb is the subset of indices in inds in this memory chunk loop that are gaussian
+            match, gauss_inds_use, inds, suba, subb
+            source_envelope = fltarr(N_elements(suba),N_elements(xvals),/NOZERO)
+            rot_inds = where(gaussian_rot[suba] NE 0,n_rot,complement=unrot_inds,ncomplement=n_unrot)
+            ;rot_inds = where(gaussian_rot[gauss_inds_use[suba]] NE 0,n_rot,complement=unrot_inds,ncomplement=n_unrot)
+            if n_rot gt 0 then begin
+                ; For gaussians that are rotated with respect to the x,y plane, calculate their source envelope
+                bin_rot_subset = suba[rot_inds]
+                ;bin_rot_subset = gauss_inds_use[suba[rot_inds]]
+                cos_rot = Cos(gaussian_rot[bin_rot_subset])
+                sin_rot = Sin(gaussian_rot[bin_rot_subset])
+
+                source_envelope[rot_inds,*] = exp(-1./2 * $
+                  (matrix_multiply(gauss_x_use2[bin_rot_subset]*cos_rot^2.+gauss_y_use2[bin_rot_subset]*sin_rot^2., xvals2) $
+                  + matrix_multiply(gauss_x_use2[bin_rot_subset]*sin_rot^2.+gauss_y_use2[bin_rot_subset]*cos_rot^2., yvals2)) $
+                  + matrix_multiply((gauss_y_use2[bin_rot_subset]-gauss_x_use2[bin_rot_subset])*cos_rot*sin_rot, xvals*yvals))
+            endif
+            if n_unrot gt 0 then begin
+                ; For aligned gaussians, avoid extra operations by directly calculating their source envelope with rot=0
+                bin_unrot_subset = suba[unrot_inds]
+                ;bin_unrot_subset = gauss_inds_use[suba[unrot_inds]]
+                source_envelope[unrot_inds,*] = exp(-1./2*(matrix_multiply(gauss_x_use2[bin_unrot_subset], xvals2) $
+                  + matrix_multiply(gauss_y_use2[bin_unrot_subset], yvals2)))
+            endif
+
+            cos_term[subb,*] *= source_envelope
+            sin_term[subb,*] *= source_envelope
+            ;cos_term[inds[subb],*] *= source_envelope
+            ;sin_term[inds[subb],*] *= source_envelope
+        ENDIF
+
+        IF size(flux_use,/type) EQ 10 THEN BEGIN
             FOR fbin_i=0L,n_fbin-1 DO BEGIN
                 flux_vals=(*flux_use[fbin_use[fbin_i]])[inds]
-                source_uv_real_vals=matrix_multiply(cos_term,flux_vals)
-                source_uv_im_vals=matrix_multiply(sin_term,flux_vals)
+                source_uv_real_vals=matrix_multiply(flux_vals,cos_term)
+                source_uv_im_vals=matrix_multiply(flux_vals,sin_term)
                 *source_uv_vals[fbin_use[fbin_i]]+=Temporary(source_uv_real_vals) + icomp * Temporary(source_uv_im_vals)
             ENDFOR
-            cos_term=(sin_term=0) ;free memory
-        ENDFOR
-    ;*****End of memory-managed DFT
+        ENDIF ELSE BEGIN
+            source_uv_real_vals=matrix_multiply(flux_use[inds], Temporary(cos_term))
+            source_uv_im_vals=matrix_multiply(flux_use[inds], Temporary(sin_term))
+            source_uv_vals+=Temporary(source_uv_real_vals) + icomp * Temporary(source_uv_im_vals)
+        ENDELSE
 
+    ENDFOR
+
+ENDIF ELSE BEGIN
+    ; DFT without memory management
+
+    phase=matrix_multiply(x_use,xvals)+matrix_multiply(y_use,yvals)
+    cos_term=Cos(phase)
+    sin_term=Sin(Temporary(phase))
+
+    IF keyword_set(gaussian_source_models) THEN BEGIN
+        source_envelope = fltarr(n_gauss, N_elements(xvals),/NOZERO)
+        rot_inds = where(gaussian_rot NE 0,n_rot,complement=unrot_inds,ncomplement=n_unrot)
+           
+        if n_rot gt 0 then begin
+            ; For gaussians that are rotated with respect to the x,y plane, calculate their source envelope
+            cos_rot = Cos(gaussian_rot[rot_inds])
+            sin_rot = Sin(gaussian_rot[rot_inds])
+            source_envelope[rot_inds,*] = exp(-1./2 * $
+              (matrix_multiply(gauss_x_use2[rot_inds]*cos_rot^2.+gauss_y_use2[rot_inds]*sin_rot^2., xvals2) $
+              + matrix_multiply(gauss_x_use2[rot_inds]*sin_rot^2.+gauss_y_use2[rot_inds]*cos_rot^2., yvals2)) $
+              + matrix_multiply((gauss_y_use2[rot_inds]-gauss_x_use2[rot_inds])*cos_rot*sin_rot, xvals*yvals))
+        endif
+        if n_unrot gt 0 then begin
+            ; For aligned gaussians, avoid extra operations by directly calculating their source envelope with rot=0
+            source_envelope[unrot_inds,*] = exp(-1./2 *(matrix_multiply(gauss_x_use2[unrot_inds], xvals2) $
+              + matrix_multiply(gauss_y_use2[unrot_inds], yvals2)))
+        endif
+        cos_term[gauss_inds_use,*] *= source_envelope
+        sin_term[gauss_inds_use,*] *= source_envelope
+    ENDIF
+
+    IF size(flux_use,/type) EQ 10 THEN BEGIN
+        FOR fbin_i=0L,n_fbin-1 DO BEGIN
+            source_uv_real_vals=matrix_multiply(*flux_use[fbin_use[fbin_i]], cos_term)
+            source_uv_im_vals=matrix_multiply(*flux_use[fbin_use[fbin_i]], sin_term)
+            *source_uv_vals[fbin_use[fbin_i]]+=DComplex(source_uv_real_vals,source_uv_im_vals)
+        ENDFOR
     ENDIF ELSE BEGIN
-      phase=matrix_multiply(xvals,x_use)+matrix_multiply(yvals,y_use)
-      cos_term=Cos(phase)
-      sin_term=Sin(Temporary(phase))
-      IF keyword_set(gaussian_source_models) THEN BEGIN
-        if n_elements(gaussian_rot) gt 0 then begin
-          source_envelope = exp(-1./2 * $
-            (matrix_multiply(xvals^2., gauss_x_use^2.*Cos(gaussian_rot)^2.+gauss_y_use^2.*Sin(gaussian_rot)^2.) $
-            + matrix_multiply(yvals^2., gauss_x_use^2.*Sin(gaussian_rot)^2.+gauss_y_use^2.*Cos(gaussian_rot)^2.)) $
-            + matrix_multiply(xvals*yvals, (gauss_y_use^2.-gauss_x_use^2.)*Cos(gaussian_rot)*Sin(gaussian_rot)))
-        endif else begin
-          source_envelope = exp(-1./2 *(matrix_multiply(xvals^2., gauss_x_use^2.)+matrix_multiply(yvals^2., gauss_y_use^2.)))
-        endelse
-        cos_term *= source_envelope
-        sin_term *= source_envelope
-      ENDIF
-      FOR fbin_i=0L,n_fbin-1 DO BEGIN
-        source_uv_real_vals=matrix_multiply(cos_term,*flux_use[fbin_use[fbin_i]])
-        source_uv_im_vals=matrix_multiply(sin_term,*flux_use[fbin_use[fbin_i]])
-        *source_uv_vals[fbin_use[fbin_i]]+=DComplex(source_uv_real_vals,source_uv_im_vals)
-      ENDFOR
-      cos_term=(sin_term=0) ;free memory
-    ENDELSE
+        source_uv_real_vals=matrix_multiply(flux_use[inds], Temporary(cos_term))
+        source_uv_im_vals=matrix_multiply(flux_use, Temporary(sin_term))
+        source_uv_vals=Temporary(source_uv_real_vals) + icomp * Temporary(source_uv_im_vals)
+    ENDELSE 
+
+ENDELSE
+cos_term=(sin_term=0) ;free memory
+
+IF size(flux_use,/type) EQ 10 THEN BEGIN    
     FOR fbin_i=0L,n_fbin-1 DO *source_uv_vals[fbin_use[fbin_i]]*=fft_norm
     IF not Keyword_Set(double_precision) THEN $
       FOR fbin_i=0L,n_fbin-1 DO $
       *source_uv_vals[fbin_use[fbin_i]]=Complex(Temporary(*source_uv_vals[fbin_use[fbin_i]]))
-  ENDIF ELSE BEGIN
-    IF Keyword_Set(conserve_memory) AND (element_check GT mem_thresh) THEN BEGIN
-        memory_bins=Round(element_check/mem_thresh)
-        source_uv_vals=DComplexarr(size(xvals,/dimension))
-        n0=N_Elements(x_use)
-        binsize=Lonarr(memory_bins)+Round(n0/memory_bins)
-        binsize[memory_bins-1]-=Total(binsize)-n0
-        bin_start=[0,Total(binsize,/cumulative)]
-        FOR bin_i=0L,memory_bins-1 DO BEGIN
-            inds=lindgen(binsize[bin_i])+bin_start[bin_i]
-            phase=matrix_multiply(xvals,x_use[inds])+matrix_multiply(yvals,y_use[inds])
-            cos_term=Cos(phase)
-            sin_term=Sin(Temporary(phase))
-            IF keyword_set(gaussian_source_models) THEN BEGIN
-              if n_elements(gaussian_rot) gt 0 then begin
-                source_envelope = exp(-1./2 * $
-                  (matrix_multiply(xvals^2., gauss_x_use[inds]^2.*Cos(gaussian_rot[inds])^2.+gauss_y_use[inds]^2.*Sin(gaussian_rot[inds])^2.) $
-                  + matrix_multiply(yvals^2., gauss_x_use[inds]^2.*Sin(gaussian_rot[inds])^2.+gauss_y_use[inds]^2.*Cos(gaussian_rot[inds])^2.)) $
-                  + matrix_multiply(xvals*yvals, (gauss_y_use[inds]^2.-gauss_x_use[inds]^2.)*Cos(gaussian_rot[inds])*Sin(gaussian_rot[inds])))
-              endif else begin
-                source_envelope = exp(-1./2 *(matrix_multiply(xvals^2., gauss_x_use[inds]^2.)+matrix_multiply(yvals^2., gauss_y_use[inds]^2.)))
-              endelse
-              cos_term *= source_envelope
-              sin_term *= source_envelope
-            ENDIF
-            source_uv_real_vals=matrix_multiply(Temporary(cos_term),flux_use[inds])
-            source_uv_im_vals=matrix_multiply(Temporary(sin_term),flux_use[inds])
-            source_uv_vals+=Temporary(source_uv_real_vals) + icomp * Temporary(source_uv_im_vals)
-        ENDFOR
-    ENDIF ELSE BEGIN
-        phase=matrix_multiply(xvals,x_use)+matrix_multiply(yvals,y_use)
-        cos_term=Cos(phase)
-        sin_term=Sin(Temporary(phase))
-        IF keyword_set(gaussian_source_models) THEN BEGIN
-          if n_elements(gaussian_rot) gt 0 then begin
-            source_envelope = exp(-1./2 * $
-              (matrix_multiply(xvals^2., gauss_x_use^2.*Cos(gaussian_rot)^2.+gauss_y_use^2.*Sin(gaussian_rot)^2.) $
-              + matrix_multiply(yvals^2., gauss_x_use^2.*Sin(gaussian_rot)^2.+gauss_y_use^2.*Cos(gaussian_rot)^2.)) $
-              + matrix_multiply(xvals*yvals, (gauss_y_use^2.-gauss_x_use^2.)*Cos(gaussian_rot)*Sin(gaussian_rot)))
-          endif else begin
-            source_envelope = exp(-1./2 *(matrix_multiply(xvals^2., gauss_x_use^2.)+matrix_multiply(yvals^2., gauss_y_use^2.)))
-          endelse
-          cos_term *= source_envelope
-          sin_term *= source_envelope
-        ENDIF
-        source_uv_real_vals=matrix_multiply(Temporary(cos_term),flux_use[inds])
-        source_uv_im_vals=matrix_multiply(Temporary(sin_term),flux_use)
-        source_uv_vals=Temporary(source_uv_real_vals) + icomp * Temporary(source_uv_im_vals)
-    ENDELSE
+ENDIF ELSE BEGIN
     source_uv_vals*=fft_norm
     IF not Keyword_Set(double_precision) THEN source_uv_vals=Complex(source_uv_vals)
 ENDELSE
+
 
 IF Keyword_Set(flux_ptr_cleanup) THEN Ptr_free,flux_use
 RETURN,source_uv_vals


### PR DESCRIPTION
I updated the gaussian source model generation. There are a couple of changes:

1) better gaussian parameter passing. I created a new structure so things are now much more compact and easier to manage.

2) including image plane -> uvw compression math from Jaiden's upcoming paper. Instead of calculating the mean compression from output from `apply_astrometry`, I'm calculating the expected compression using geometry. I've attached a screenshot of the relevant math. 

<img width="1059" alt="Screen Shot 2022-05-16 at 10 54 03 am" src="https://user-images.githubusercontent.com/5588290/168745007-e614b83a-89d2-4afe-b75e-43906313cece.png">

3) switching the `source_dft` matrix ordering so that it's column major to be faster in IDL. This was a simple fix that significantly decreased walltime and mem requirements.

4) small bugs and general spacing. 

The main branch (with Christene's LoBES catalog) took 381 min at 94 Gb for 69 118 sources. The new branch took 326 min at 65 Gb for the same sources. Running the main branch and the new branch with just point sources yielded the exact same power spectra. 

Here is the difference between the old branch and the new branch (blue means less power in the new branch).
![fhd_nb_data_pointing_beam_lobes_update_int_fullimg_dft_averemove_swbh_dencorr__oldbranch_1061316296_minus_newbranch_FoV_1061316296_2dkpower](https://user-images.githubusercontent.com/5588290/168745313-e592fc73-d0f7-4b78-aebe-633dc9935f1e.png)

And here is the ratio difference between the old branch and the new branch (blue means more power was removed in the new branch.
![fhd_nb_data_pointing_beam_lobes_update_int_fullimg_dft_averemove_swbh_dencorr__oldbranch_1061316296_diffratio_newbranch_FoV_1061316296_2dkpower](https://user-images.githubusercontent.com/5588290/168745420-af095012-cbae-48cf-9f1b-7df637010904.png)

The difference suggests that the geometrical argument behaves better than the mean calculation as projection effects increase towards the horizon.
