### PR TITLE
Fix bugs causing errors while gridding/degridding

### DIFF
--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -128,6 +128,15 @@ IF N_Elements(min_baseline) EQ 0 THEN min_baseline=Min(kr_arr[where(kr_arr)]) EL
 kx_arr=0 & ky_arr=0 & kr_arr=0 ;free memory
 noise_arr=Ptr_new()
 
+; check that all elements in the antenna1 and antenna2 array exist in the antenna numbers
+; from the uvfits antenna table
+all_ants = [params.antenna1, params.antenna2]
+uniq_ants = all_ants[uniq(all_ants)]
+for i=0, n_elements(uniq_ants)-1 do begin
+    ind = where(uniq_ants[i] EQ (layout.antenna_numbers), n_count)
+    if n_count EQ 0 then message, "antenna arrays contain number(s) not found in antenna table"
+endfor
+
 ; fhd expects antenna1 and antenna2 arrays containing indices that are one-indexed. 
 ; Some uvfits files contain actual antenna numbers in these fields, while others  
 ; (particularly, those written by cotter or birli) contain indices.

--- a/fhd_core/visibility_manipulation/vis_header_extract.pro
+++ b/fhd_core/visibility_manipulation/vis_header_extract.pro
@@ -75,8 +75,7 @@ date_i=where(Strmatch(param_list,'DATE', /fold_case),found_date) & IF found_date
 IF (found_baseline NE 1) OR (found_uu NE 1) OR (found_vv NE 1) OR (found_ww NE 1) OR (found_date LT 1) THEN error=1 
 
 IF found_date GT 1 THEN BEGIN
-    Jdate0=Double(sxpar(header,String(format='("PZERO",I1)',date_i[0]+1))) + Double(params[date_i[0],0])
-    date_i=date_i[1]
+    Jdate0=Double(sxpar(header,String(format='("PZERO",I1)',date_i[0]+1)))
 ENDIF ELSE BEGIN
     Jdate0=Double(sxpar(header,String(format='("PZERO",I1)',date_i+1)))
 ENDELSE

--- a/fhd_core/visibility_manipulation/vis_param_extract.pro
+++ b/fhd_core/visibility_manipulation/vis_param_extract.pro
@@ -4,7 +4,12 @@ FUNCTION vis_param_extract,params,header, antenna_mod_index=antenna_mod_index
 uu_arr=Double(reform(params[header.uu_i,*]))
 vv_arr=Double(reform(params[header.vv_i,*]))
 ww_arr=Double(reform(params[header.ww_i,*]))
-time=reform(params[header.date_i,*])
+
+; Use both date fields if available in the uvfits file
+; The center value is not added automatically, so add jd0
+IF n_elements(header.date_i) GT 1 THEN BEGIN
+    time=Double(reform(params[header.date_i[0],*])) + Double(reform(params[header.date_i[1],*])) + Double(header.jd0)
+ENDIF ELSE time=Double(reform(params[header.date_i,*]))
 
 ; Sort out the baseline numbering and antenna numbers
 IF header.baseline_i GE 0 THEN $

--- a/fhd_core/visibility_manipulation/vis_param_extract.pro
+++ b/fhd_core/visibility_manipulation/vis_param_extract.pro
@@ -6,8 +6,8 @@ vv_arr=Double(reform(params[header.vv_i,*]))
 ww_arr=Double(reform(params[header.ww_i,*]))
 
 ; Use both date fields if available in the uvfits file
-; The center value is not added automatically, so add jd0
-IF n_elements(header.date_i) GT 1 THEN BEGIN
+; This doesn't give julian dates; those are calcuated in fhd_struct_init_meta
+IF n_elements(header.date_i) EQ 2 THEN BEGIN
     time=Double(reform(params[header.date_i[0],*])) + Double(reform(params[header.date_i[1],*]))
 ENDIF ELSE time=Double(reform(params[header.date_i,*]))
 

--- a/fhd_core/visibility_manipulation/vis_param_extract.pro
+++ b/fhd_core/visibility_manipulation/vis_param_extract.pro
@@ -8,7 +8,7 @@ ww_arr=Double(reform(params[header.ww_i,*]))
 ; Use both date fields if available in the uvfits file
 ; The center value is not added automatically, so add jd0
 IF n_elements(header.date_i) GT 1 THEN BEGIN
-    time=Double(reform(params[header.date_i[0],*])) + Double(reform(params[header.date_i[1],*])) + Double(header.jd0)
+    time=Double(reform(params[header.date_i[0],*])) + Double(reform(params[header.date_i[1],*]))
 ENDIF ELSE time=Double(reform(params[header.date_i,*]))
 
 ; Sort out the baseline numbering and antenna numbers


### PR DESCRIPTION
Some uvfits files were resulting in the following error during gridding/degridding:
`% Unable to dereference NULL pointer: <POINTER  (<NullPointer>)>.`

This was tracked down to two different bugs. In one case, the code which maps antenna numbers to indices was not being triggered. In another case, only using one of the two uvfits date fields resulted in an incorrect calculation of the number of baselines.

Both of these bugs are fixed here. Additionally, I have added a check which makes sure that all the elements from the uvfits header antenna arrays are present in the antenna numbers array from the antenna table.