### PR TITLE
Make transfer_psf work when beams and obs are in different directories

### DIFF
--- a/fhd_core/beam_modeling/beam_setup.pro
+++ b/fhd_core/beam_modeling/beam_setup.pro
@@ -21,7 +21,7 @@ FUNCTION beam_setup,obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_l
   IF Keyword_set(transfer_psf) then begin
     ;
     ; Transfer a psf/obs structure from previous run or from a specified file
-    if file_test(transfer_psf) then begin
+    if file_test(transfer_psf, /REGULAR) then begin
       psf = getvar_savefile(transfer_psf,'psf')
       obs_restore = getvar_savefile(transfer_psf,'obs')
     endif else begin


### PR DESCRIPTION
Minor update to allow `transfer_psf` keyword to work when the `beams` and `obs` structures are in different directories (as is true for the default output format). Previously, the if statement on line 24 would pass when `transfer_psf` was a directory, and then fail in `getvar_savefile` when trying to restore the directory - this change means that this if statement is skipped if the keyword is a directory rather than a file, and is instead handled in the following chunk of code.