### PR TITLE
Fix indexing for `vis_baseline_hist`

### DIFF
--- a/fhd_core/visibility_manipulation/vis_baseline_hist.pro
+++ b/fhd_core/visibility_manipulation/vis_baseline_hist.pro
@@ -18,11 +18,11 @@ dist_hist = histogram(dist_arr, min=obs.min_baseline, binsize=5, max=obs.max_bas
             wh_noflag = where(Abs(model_vals) GT 0, count_noflag)
             IF count_noflag EQ 0 THEN CONTINUE ELSE inds = inds[wh_noflag]
             if Keyword_Set(calibration_visibilities_subtract) THEN BEGIN
-                vis_res_ratio_mean[i] = mean(abs((*vis_arr[pol_i])[inds]))/mean(abs(model_vals))
-                vis_res_sigma[i] = sqrt(variance(abs((*vis_arr[pol_i])[inds])))/mean(abs(model_vals))
+                vis_res_ratio_mean[pol_i, i] = mean(abs((*vis_arr[pol_i])[inds]))/mean(abs(model_vals))
+                vis_res_sigma[pol_i, i] = sqrt(variance(abs((*vis_arr[pol_i])[inds])))/mean(abs(model_vals))
             ENDIF ELSE BEGIN
-                vis_res_ratio_mean[i] = mean(abs((*vis_arr[pol_i])[inds]-model_vals))/mean(abs(model_vals))
-                vis_res_sigma[i] = sqrt(variance(abs((*vis_arr[pol_i])[inds]-model_vals)))/mean(abs(model_vals))
+                vis_res_ratio_mean[pol_i, i] = mean(abs((*vis_arr[pol_i])[inds]-model_vals))/mean(abs(model_vals))
+                vis_res_sigma[pol_i, i] = sqrt(variance(abs((*vis_arr[pol_i])[inds]-model_vals)))/mean(abs(model_vals))
             ENDELSE
         ENDIF
     ENDFOR


### PR DESCRIPTION
This fixes an indexing issue found by Jack (@JLBLine) during the PyFHD testing, this should fix the results and save the values in each polarization rather than overwriting each polarization per loop inside the `vis_res_ratio_mean` and `vis_res_sigma` arrays. PyFHD and FHD get *almost* (precision error) the same results with this fix applied.

The previous `vis_baseline_hist`:

![test_vis_baseline_hist_point_zenith_run1](https://github.com/EoRImaging/FHD/assets/22165180/8af5a8e9-7ed7-402b-9d0b-5583063c287d)

The fixed `vis_baseline_hist`:

![test_vis_baseline_hist_point_zenith_run1_after_fix](https://github.com/EoRImaging/FHD/assets/22165180/1b220126-22ce-4f19-a142-c329f0d9aee5)

