### PR TITLE
quadratic interpolation of the beam in freq

### DIFF
--- a/instrument_config/mwa_beam_setup_gain.pro
+++ b/instrument_config/mwa_beam_setup_gain.pro
@@ -75,7 +75,7 @@ CASE beam_model_version OF
         Jmat_interp=Ptrarr(n_ant_pol,n_ant_pol,nfreq_bin)
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR freq_i=0L,nfreq_bin-1 DO Jmat_interp[p_i,p_j,freq_i]=Ptr_new(Dcomplexarr(n_ang))
         FOR p_i=0,n_ant_pol-1 DO FOR p_j=0,n_ant_pol-1 DO FOR a_i=0L,n_ang-1 DO BEGIN
-            Jmat_single_ang=Interpol(Jmat_arr[*,p_i,p_j,a_i],freq_arr_Jmat,freq_center);*norm_factor
+            Jmat_single_ang=Interpol(Jmat_arr[*,p_i,p_j,a_i],freq_arr_Jmat,freq_center,/quadratic);*norm_factor
             FOR freq_i=0L,nfreq_bin-1 DO (*Jmat_interp[p_i,p_j,freq_i])[a_i]=Jmat_single_ang[freq_i]
 ;            (*Jmat_interp[p_i,p_j])[a_i]=Interpol(Jmat_arr[*,p_i,p_j,a_i],freq_arr_Jmat,freq_center)
         ENDFOR


### PR DESCRIPTION
Changing the default option on the interpolation on the beam in frequency from linear to quadratic to remove the coarse band lines in simulation.

![Power_Spectrum_Plot](https://github.com/EoRImaging/FHD/assets/5588290/e613cc10-d8a3-48ee-986f-58137983708e)
