### PR TITLE
make uvf cube outputs be 3D arrays rather than pointer arrays

### DIFF
--- a/fhd_core/gridding/vis_model_freq_split.pro
+++ b/fhd_core/gridding/vis_model_freq_split.pro
@@ -97,10 +97,17 @@ FUNCTION vis_model_freq_split,obs,status_str,psf,params,vis_weights,model_uv_arr
     n_vis_use=0.
 
     if keyword_set(save_uvf) then begin
-      dirty_uv_arr=Complexarr(dimension, dimension, nf)
-      weights_uv_arr=Complexarr(dimension, dimension, nf)
-      variance_uv_arr=Complexarr(dimension, dimension, nf)
-      IF Keyword_Set(model_flag) THEN model_uv_arr=Complexarr(dimension, dimension, nf)
+      if obs.double_precision then begin
+        dirty_uv_arr=dcomplexarr(dimension, dimension, nf)
+        weights_uv_arr=dcomplexarr(dimension, dimension, nf)
+        variance_uv_arr=dcomplexarr(dimension, dimension, nf)
+        IF Keyword_Set(model_flag) THEN model_uv_arr=dcomplexarr(dimension, dimension, nf)
+      endif else begin
+        dirty_uv_arr=complexarr(dimension, dimension, nf)
+        weights_uv_arr=complexarr(dimension, dimension, nf)
+        variance_uv_arr=complexarr(dimension, dimension, nf)
+        IF Keyword_Set(model_flag) THEN model_uv_arr=complexarr(dimension, dimension, nf)
+      endelse
     endif
 
     FOR fi=0L,nf-1 DO BEGIN

--- a/outputs.md
+++ b/outputs.md
@@ -179,9 +179,12 @@ Text file of generated bandpass solutions. The first column is the frequency cha
 
   * **vis_count**: an image of dimensions N<sub>dimension</sub> by N<sub>elements</sub> (where dimension and elements are FHD keywords). Each pixel value is how many visibilities contributed to that pixel, which is the same as our in-house uniform weighting. (!Q right?)
 
+### \<obsids\>\_\<even/odd\>\_gridded_uvf_\<pol\>.sav <br />
+Gridded uvf cubes, alternative input to eppsilon. Saved only if keyword `save_uvf` is set.
+
 ##  HEALPix<br />
 
-### \<obsids\>\_even_cube\<pol\>.sav / \<obsids\>_even_cube\<pol\>.sav <br />
+### \<obsids\>\_\<even/odd\>_cube\<pol\>.sav
 
   * **variance_cube/weights_cube**: an array of HEALPix pixels organized by hpx_inds for each output frequency. This is an image cube of 1's gridded with the beam for all visibilities (weights) or 1's gridded with the beam squared for all visibilities (variances).
 
@@ -371,12 +374,6 @@ Residual image with the subtracted sources over-plotted. Each source is plotted 
 
 ### \<obsids\>\_\<filter\>\_UV_weights_\<pol\>.png <br />
 
-##  UVF Cubes<br />
-Saved only if keyword `save_uvf` is set.
-
-### \<obsids\>\_even_gridded_uvf.sav <br />
-
-### \<obsids\>\_odd_gridded_uvf.sav <br />
 
 ##  Vis Data<br />
 


### PR DESCRIPTION
Also separate pols into different files and save uvf cubes in the `grid_data` subfolder.

Going to 3D complex arrays rather than pointers and separating the pols into different files speed up eppsilon significantly.

The new location for the cubes keeps the folder structure clean but does require some minor updates on eppsilon.