### PR TITLE
convert tile flag to cross-corr flags

### DIFF
--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -14,6 +14,8 @@ git,'describe',result=code_version,repo_path=rootdir('fhd'),args='--long --dirty
 IF N_Elements(code_version) GT 0 THEN code_version=code_version[0] ELSE code_version=''
 
 IF N_Elements(n_pol) EQ 0 THEN n_pol=hdr.n_pol
+pol_names=['XX','YY','XY','YX','I','Q','U','V']
+
 IF Tag_exist(layout, "n_antenna") THEN BEGIN
     n_tile=layout.n_antenna 
 ENDIF ELSE BEGIN
@@ -160,7 +162,7 @@ params.antenna1 = tile_A
 params.antenna2 = tile_B
 
 meta=fhd_struct_init_meta(file_path_vis,hdr,params,layout,degpix=degpix,dimension=dimension,elements=elements,$
-    n_tile=n_tile,instrument=instrument,meta_data=meta_data,meta_hdr=meta_hdr,_Extra=extra)
+    n_tile=n_tile,instrument=instrument,pol_names=pol_names,meta_data=meta_data,meta_hdr=meta_hdr,_Extra=extra)
 
 IF N_Elements(meta_data) EQ 0 THEN meta_data=Ptr_new() ELSE meta_data=Ptr_new(meta_data)
 IF N_Elements(meta_hdr) EQ 0 THEN meta_hdr=Ptr_new() ELSE meta_hdr=Ptr_new(meta_hdr)
@@ -179,7 +181,6 @@ FOR ti=0,N_Elements(time_cut)<2-1 DO BEGIN
     IF ti_end GE ti_start THEN time_use[ti_start:ti_end]=0
 ENDFOR
 n_time_cut = n_time - Total(time_use)
-
 tile_use1=intarr(n_tile)
 FOR pol_i=0,n_pol-1 DO BEGIN
     tile_use_i=where(*(meta.tile_flag[pol_i]) EQ 0,n_use)
@@ -205,7 +206,7 @@ IF dimension GT 4096 THEN BEGIN
         double_precision=1
     ENDIF
 ENDIF
-pol_names=['XX','YY','XY','YX','I','Q','U','V']
+
 healpix={nside:Long(nside),ind_list:String(ind_list),n_pix:Long(n_hpx),n_zero:Long(n_zero_hpx)}
 
 arr={tile_A:Long(tile_A),tile_B:Long(tile_B),bin_offset:Long(bin_offset),Jdate:meta.Jdate,freq:Double(frequency_array),fbin_i:Long(freq_bin_i),$
@@ -215,7 +216,7 @@ struct={code_version:String(code_version),instrument:String(instrument),obsname:
     kpix:Float(kbinsize),degpix:Float(degpix),obsaz:meta.obsaz,obsalt:meta.obsalt,obsra:meta.obsra,obsdec:meta.obsdec,$
     zenra:meta.zenra,zendec:meta.zendec,obsx:meta.obsx,obsy:meta.obsy,zenx:meta.zenx,zeny:meta.zeny,$
     phasera:meta.phasera,phasedec:meta.phasedec,orig_phasera:meta.orig_phasera,orig_phasedec:meta.orig_phasedec,$
-    n_pol:Fix(n_pol,type=2),n_tile:Long(n_tile),n_tile_flag:Long(n_flag),n_freq:Long(n_freq),n_freq_flag:0L,n_time:Long(n_time),n_time_flag:n_time_cut,$
+    n_pol:Fix(n_pol,type=2),n_tile:Long(n_tile),n_tile_flag:Long(n_flag),n_freq:Long(n_freq),n_freq_flag:0L,n_time:Long(n_time),n_time_flag:Long(n_time_cut),$
     n_vis:Long(n_vis),n_vis_in:Long(n_vis_in),n_vis_raw:Long(n_vis_raw),nf_vis:Long(n_vis_arr),primary_beam_area:Ptrarr(4),primary_beam_sq_area:Ptrarr(4),pol_names:pol_names,$
     jd0:meta.jd0,max_baseline:Double(max_baseline),min_baseline:Double(min_baseline),delays:meta.delays,lon:meta.lon,lat:meta.lat,alt:meta.alt,$
     freq_center:Float(freq_center),freq_res:Float(freq_res),time_res:Float(meta.time_res),astr:meta.astr,alpha:Float(spectral_index),$


### PR DESCRIPTION
This one is bit complicated. This is in response to issue #311 .

The suggested fix in #311 could be more generalized. For example, the metadata file is actually structured such that the Y pol is before the X pol (why?!?!). Even though we currently flag XX, YY, XY, and YX the same *currently* doesn't mean we always will want that. Therefore, I've constructed a way that is generalized.

Essentially, the code grabs the individual dipole flags and matches their metadata name (i.e. X) to a component in the cross-correlation name (i.e. XY). Then a logical OR is performed to get the cross-correlation flag. 

So, an X-dipole flag will end up flagging XX, XY, and YX. But not YY.

No difference in the 2-pol. Only difference is in 4-pol flagging.

This will need to be implemented in pyFHD (low-priority) -- I will make an issue and link it.