### PR TITLE
Proper tracking of flagged times

### DIFF
--- a/fhd_core/setup_metadata/fhd_struct_init_obs.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_obs.pro
@@ -215,7 +215,7 @@ struct={code_version:String(code_version),instrument:String(instrument),obsname:
     kpix:Float(kbinsize),degpix:Float(degpix),obsaz:meta.obsaz,obsalt:meta.obsalt,obsra:meta.obsra,obsdec:meta.obsdec,$
     zenra:meta.zenra,zendec:meta.zendec,obsx:meta.obsx,obsy:meta.obsy,zenx:meta.zenx,zeny:meta.zeny,$
     phasera:meta.phasera,phasedec:meta.phasedec,orig_phasera:meta.orig_phasera,orig_phasedec:meta.orig_phasedec,$
-    n_pol:Fix(n_pol,type=2),n_tile:Long(n_tile),n_tile_flag:Long(n_flag),n_freq:Long(n_freq),n_freq_flag:0L,n_time:Long(n_time),n_time_flag:n_time_cut,$
+    n_pol:Fix(n_pol,type=2),n_tile:Long(n_tile),n_tile_flag:Long(n_flag),n_freq:Long(n_freq),n_freq_flag:0L,n_time:Long(n_time),n_time_flag:Long(n_time_cut),$
     n_vis:Long(n_vis),n_vis_in:Long(n_vis_in),n_vis_raw:Long(n_vis_raw),nf_vis:Long(n_vis_arr),primary_beam_area:Ptrarr(4),primary_beam_sq_area:Ptrarr(4),pol_names:pol_names,$
     jd0:meta.jd0,max_baseline:Double(max_baseline),min_baseline:Double(min_baseline),delays:meta.delays,lon:meta.lon,lat:meta.lat,alt:meta.alt,$
     freq_center:Float(freq_center),freq_res:Float(freq_res),time_res:Float(meta.time_res),astr:meta.astr,alpha:Float(spectral_index),$


### PR DESCRIPTION
This fix addresses issue #321, where the auto calibration was using times which should have been flagged.

This underlying root cause is that the time_use array was not checked against the weights array. In the case of SSINS, the weights for an entire time step will flagged, but this was not propagating to the time_use array in FHD. The time_use array is used a few circumstances, the two major instances being 1) auto calibration averaging and 2) noise calculation. Given that this affects the results in a few places, there is an overall change in the PS.

Below is a test against a control for an observation that had 4 SSINS flagged times. Differences are small and somewhat hard to interpret. Not sure if we want to pursue this differences deeper or if we are happy to take the fact that this is the proper time_use handling. 

![fhd_nb_ntime_noimgclip_dft_averemove_swbh_dencorr__control2_1088281088_minus_test2_1088281088_2dkpower](https://github.com/user-attachments/assets/936d6fbf-3d03-43cc-ade4-7f01b64a09f6)
![fhd_nb_ntime_noimgclip_dft_averemove_swbh_dencorr__control2_1088281088_diffratio_test2_1088281088_2dkpower](https://github.com/user-attachments/assets/701db103-7dd6-4552-aecb-54d01d8ca16a)
