### PR TITLE
Reducing skymodel confusion

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -225,7 +225,6 @@ This is a work in progress; please add keywords as you find them in alphabetical
   -*Default*: equal to `max_baseline` <br />
 
 **max_calibration_sources**: limits the number of sources used in the calibration. Sources are weighted by apparent brightness before applying the cut. Note that extended sources with many associated source components count as only a single source. <br />
-  -*Dependency*: The sources are also included in the model if `return_cal_visibilities` is set. <br />
   -*Default*: All valid sources in the catalog are used. <br />
 
 **min_cal_baseline**: the minimum baseline length in wavelengths to be used in calibration. <br />
@@ -417,6 +416,11 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Default*: Unset, unless model_visibilities and model_subtract_sidelobe_catalog are set OR deconvolve and subtract_sidelobe_catalog are set <br />
   -*eor_wrapper_defaults*: 1 <br />
 
+**combine_skymodels**: combines the calibration and model skymodel together. Sources are marked as duplicates if matched by 1/100th of a pixel. If `return_cal_visibilities` is set, then only the non-duplicate model sources are calculated, which are added to the returned calibration visibilities to build the full model. This assumes that the calibration skymodel is a subset of the model skymodel. This reduces the number of calculations and is thus more efficient. If `return_cal_visibilities` is not set, then the entire model skymodel is calculated. If `save_skymodel` is set, then the calibration skymodel (marked with `include_calibration=1` in the structure) and non-duplicate model skymodel (marked with `include_calibration=0` in the structure) are saved as one output. <br />
+  -*Dependency*: `calibrate_visibilities` and `model_visibilities` must be set to 1 <br />
+  -*Default*: Unset <br />
+  -*Turn off/on*: 0/1 <br />
+
 **conserve_memory**: split the model DFT into matrix chunks to reduce the memory load at the cost of extra walltime. If set to greater than 1e6, then it will set the maximum memory used in bytes. <br />
   -*Default*: 1 (100 Mb) <br />
   -*Turn off/on*: 0/1 (optionally set to bytes)<br />
@@ -441,7 +445,7 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Default*: 0 <br />
 
 **max_model_sources**: limits the number of sources used in the model. Sources are weighted by apparent brightness before applying the cut. Note that extended sources with many associated source components count as only a single source. <br />
-  -*Dependency*: `model_visibilities` must be set to 1 in order for the keyword to take effect. If `return_cal_visibilities` is set, then the final model will include all calibration sources and all model sources (duplicates are caught and included only once). <br />
+  -*Dependency*: `model_visibilities` must be set to 1 in order for the keyword to take effect. <br />
   -*Default*: All valid sources are used. !Q <br />
 
 **model_catalog_file_path**: a catalog of sources to be used to make model visibilities for subtraction. The source catalog can be provided as either a IDL .sav file or a .skyh5 file. A .skyh5 file must be created with pyradiosky or conform to the pyradiosky formatting convention.<br />
@@ -509,6 +513,10 @@ WARNING! Options in this section may change without notice, and should never be 
 **ring_radius**: sets the size of the rings around sources in the restored images. To generate restored images without rings, set ring_radius = 0. <br />
   -*Default*: 0 <br />
   -*eor_wrapper_defaults*: 10.x`pad_uv_image` <br />
+
+**save_skymodel**: save the skymodel. If both `calibrate_visibilities` and `model_visibilities` are set, then save them individually as `skymodel_cal` and `skymodel_model` unless `combine_skymodels` is set. <br />
+  -*Turn off/on*: 0/1 <br />
+  -*Default*: 0 <br />
 
 **save_uvf**: saves the gridded uv plane as a function of frequency for dirty, model, weights, and variance cubes. <br />
   -*Turn off/on*: 0/1 <br />

--- a/fhd_core/setup_metadata/fhd_save_io.pro
+++ b/fhd_core/setup_metadata/fhd_save_io.pro
@@ -50,7 +50,7 @@ IF Keyword_Set(text) THEN BEGIN
 ENDIF
 
 IF N_Elements(var_name) EQ 0 THEN var_name='' ELSE var_name=StrLowCase(var_name)
-IF var_name NE 'status_str' THEN IF not tag_exist(status_use,var_name) THEN RETURN
+IF var_name NE 'status_str' THEN IF ~strmatch(var_name,'skymodel*') THEN IF not tag_exist(status_use,var_name) THEN RETURN
 
 CASE var_name OF ;listed in order typically generated
     'status_str':BEGIN path_add='_status' & subdir='metadata' & END

--- a/fhd_core/setup_metadata/fhd_save_io.pro
+++ b/fhd_core/setup_metadata/fhd_save_io.pro
@@ -63,6 +63,8 @@ CASE var_name OF ;listed in order typically generated
     'jones':BEGIN status_use.jones=1 & path_add='_jones' & subdir='beams'& END
     'cal':BEGIN status_use.cal=1 & path_add='_cal' & subdir='calibration'& END
     'skymodel':BEGIN status_use.skymodel=1 & path_add='_skymodel' & subdir='output_data'& END
+    'skymodel_cal':BEGIN status_use.skymodel=1 & path_add='_skymodel_cal' & subdir='output_data'& END
+    'skymodel_model':BEGIN status_use.skymodel=1 & path_add='_skymodel_model' & subdir='output_data'& END
     'source_array':BEGIN status_use.source_array=1 & path_add='_source_array' & subdir='output_data'& END
     'vis_weights':BEGIN
         IF Tag_exist(status_use,"vis_weights") THEN status_use.vis_weights=1 ELSE status_use.flag_arr=1

--- a/fhd_core/source_modeling/fhd_struct_combine_skymodel.pro
+++ b/fhd_core/source_modeling/fhd_struct_combine_skymodel.pro
@@ -1,8 +1,16 @@
-FUNCTION fhd_struct_combine_skymodel, obs, skymodel_cal, skymodel_update, calibration_flag=calibration_flag
+FUNCTION fhd_struct_combine_skymodel, obs, skymodel_cal, skymodel_model
 
-IF N_Elements(skymodel_cal) EQ 0 THEN RETURN,skymodel_update
-IF N_Elements(skymodel_update) EQ 0 THEN RETURN,skymodel_cal
-IF N_Elements(calibration_flag) EQ 0 THEN calibration_flag=1 ;set to indicate skymodel_cal really is the calibration model
+IF N_Elements(skymodel_cal) EQ 0 THEN RETURN, skymodel_update
+IF N_Elements(skymodel_update) EQ 0 THEN RETURN, skymodel_cal
+
+;Combine calibration flag arrays to show which sources were used to calibrate
+if N_elements(skymodel_cal.include_calibration) EQ 1 THEN BEGIN
+    cal_flag = INTARR(skymodel_cal.n_sources) + skymodel_cal.include_calibration
+ENDIF ELSE cal_flag = skymodel_cal.include_calibration
+if N_elements(skymodel_update.include_calibration) EQ 1 THEN BEGIN
+    model_flag = INTARR(skymodel_update.n_sources) + skymodel_update.include_calibration
+ENDIF ELSE model_flag = skymodel_update.include_calibration
+calibration_flag = [cal_flag, model_flag]
 
 source_list=source_list_append(obs,skymodel_update.source_list,skymodel_cal.source_list)
 IF Keyword_Set(skymodel_update.diffuse_model) THEN BEGIN
@@ -26,7 +34,7 @@ ENDIF ELSE BEGIN
 ENDELSE
 
 skymodel=fhd_struct_init_skymodel(obs,source_list=source_list,$
-    return_cal=calibration_flag,catalog_path=catalog_path,$
+    include_calibration=calibration_flag,catalog_path=catalog_path,$
     galaxy_model=galaxy_model,galaxy_spectral_index=galaxy_spectral_index,$
     diffuse_model=diffuse_model,diffuse_spectral_index=diffuse_spectral_index)
 

--- a/fhd_core/source_modeling/fhd_struct_combine_skymodel.pro
+++ b/fhd_core/source_modeling/fhd_struct_combine_skymodel.pro
@@ -1,4 +1,4 @@
-FUNCTION fhd_struct_combine_skymodel, obs, skymodel_cal, skymodel_model
+FUNCTION fhd_struct_combine_skymodel, obs, skymodel_cal, skymodel_update
 
 IF N_Elements(skymodel_cal) EQ 0 THEN RETURN, skymodel_update
 IF N_Elements(skymodel_update) EQ 0 THEN RETURN, skymodel_cal
@@ -34,7 +34,7 @@ ENDIF ELSE BEGIN
 ENDELSE
 
 skymodel=fhd_struct_init_skymodel(obs,source_list=source_list,$
-    include_calibration=calibration_flag,catalog_path=catalog_path,$
+    calibration_flag=calibration_flag,catalog_path=catalog_path,$
     galaxy_model=galaxy_model,galaxy_spectral_index=galaxy_spectral_index,$
     diffuse_model=diffuse_model,diffuse_spectral_index=diffuse_spectral_index)
 

--- a/fhd_core/source_modeling/fhd_struct_init_skymodel.pro
+++ b/fhd_core/source_modeling/fhd_struct_init_skymodel.pro
@@ -1,9 +1,9 @@
 FUNCTION fhd_struct_init_skymodel,obs,source_list=source_list,catalog_path=catalog_path,$
     galaxy_model=galaxy_model,galaxy_spectral_index=galaxy_spectral_index,$
     diffuse_model=diffuse_model,diffuse_spectral_index=diffuse_spectral_index,$
-    return_cal_visibilities=return_cal_visibilities,_Extra=extra
+    calibration_flag=calibration_flag,_Extra=extra
 
-IF N_Elements(return_cal_visibilities) EQ 0 THEN calibration_flag=0 ELSE calibration_flag=return_cal_visibilities
+IF N_Elements(calibration_flag) EQ 0 THEN calibration_flag=0
 IF Keyword_Set(galaxy_model) THEN galaxy_flag=1 ELSE galaxy_flag=0
 IF Keyword_Set(diffuse_model) THEN diffuse_filepath=diffuse_model ELSE diffuse_filepath=''
 IF Keyword_Set(catalog_path) THEN catalog_path_use=file_basename(catalog_path,'.sav',/fold_case) ELSE catalog_path_use=''

--- a/fhd_core/source_modeling/source_list_append.pro
+++ b/fhd_core/source_modeling/source_list_append.pro
@@ -19,12 +19,7 @@ IF Keyword_Set(exclude_duplicate) THEN BEGIN
     ;If no unique sources, return the entire first source list.
     IF n_uniq1 GT 0 THEN source_list=source_list1[uniq_i1] ELSE source_list=source_list1
 ENDIF ELSE BEGIN
-    CASE n_dup OF
-        0:source_list=[source_list1,source_list2] 
-        n2:source_list=source_list1
-        n1:source_list=source_list2
-        ELSE:source_list=[source_list1[uniq_i1],source_list2]
-    ENDCASE
+    source_list=[source_list1,source_list2] 
 ENDELSE
 
 RETURN,source_list

--- a/fhd_core/source_modeling/source_list_append.pro
+++ b/fhd_core/source_modeling/source_list_append.pro
@@ -15,7 +15,9 @@ ENDFOR
 
 dup_i=where(dup_flag GE 0,n_dup,complement=uniq_i1,ncomplement=n_uniq1)
 IF Keyword_Set(exclude_duplicate) THEN BEGIN
-    IF n_uniq1 GT 0 THEN source_list=source_list1[uniq_i1] ELSE source_list=source_comp_init(n_sources=0)
+    ;Only use unique sources from first source list.
+    ;If no unique sources, return the entire first source list.
+    IF n_uniq1 GT 0 THEN source_list=source_list1[uniq_i1] ELSE source_list=source_list1
 ENDIF ELSE BEGIN
     CASE n_dup OF
         0:source_list=[source_list1,source_list2] 


### PR DESCRIPTION
Some skymodel behaviour was very opaque, as pointed out by Shijiao. So, I set out to make it a little more obvious what is going on.

**Previous functionality**
When `return_cal_visibilities` is set, then the calibration visibilities are kept around after calibration. If a different set of visibilities need to be calculated for the subtraction model, only sources that are *extra* to the initial calibration sources list are calculated and added to the returned calibration visibilities. This assumes that the calibration sources are a subset of the model sources. While this reduces the number of calculations, it is not obvious from the user that setting `return_cal_visiblities` would cause this behaviour.

The skymodel that is saved, regardless of whether or not `return_cal_visibilities` is set, only includes model sources that are not "duplicates" of the calibration sources. There is no indication in the source list whether a source was used in the model. Assumptions include 1) that the model is a subset, and 2) that sources that are co-located to within 1/100th of a pixel are duplicates, regardless of brightness.

**New functionality**
When `return_cal_visibilities` is set, then the calibration visibilities are kept around after calibration. If a different set of visibilities need to be calculated for the subtraction model, all will be calculated unless `combine_skymodels` is set. This gives flexibility to do the previous functionality (and be more efficient in your number of calculations) or do something more complicated where the assumptions do not apply.

When `combine_skymodels` is set, the code attempts to combine the skymodels as above. Extra model sources are marked with unsetting the `include_calibration` keyword (an already present keyword) for that source in the skymodel; duplicates are not included. If it seems as though the model is not a subset of calibration, then all sources are saved. 

If `combine_skymodels` is not set, then code will save separate skymodels.

`save_skymodels` must be set for skymodels to be saved.