### PR TITLE
Beam misc

### DIFF
--- a/fhd_core/beam_modeling/beam_setup.pro
+++ b/fhd_core/beam_modeling/beam_setup.pro
@@ -267,7 +267,10 @@ FUNCTION beam_setup,obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_l
 
         if keyword_set(beam_gaussian_decomp) then begin
           beam_int+=baseline_group_n*volume_beam
-          beam2_int+=baseline_group_n*sq_volume_beam
+          ;The analytic volume is an overestimate due to the horizon and/or clipping.
+          ;Until this is fixed, the discrete calculation will be used.
+          ;beam2_int+=baseline_group_n*sq_volume_beam
+          beam2_int+=baseline_group_n*Total(Abs(psf_base_superres)^2,/double)/psf_resolution^2.
           gaussian_params[g_i]=ptr_new(beam_gaussian_params) 
         endif else begin
           ; divide by psf_resolution^2 since the FFT is done at a different resolution and requires a different normalization
@@ -341,6 +344,7 @@ FUNCTION beam_setup,obs,status_str,antenna,file_path_fhd=file_path_fhd,restore_l
     fhd_save_io,status_str,psf_metadata,var='psf',/compress,file_path_fhd=file_path_fhd,no_save=no_save
   ENDIF ELSE fhd_save_io,status_str,psf,var='psf',/compress,file_path_fhd=file_path_fhd,no_save=no_save
 
+  fhd_save_io,status_str,obs,var='obs',/compress,file_path_fhd=file_path_fhd
   fhd_save_io,status_str,antenna,var='antenna',/compress,file_path_fhd=file_path_fhd,no_save=~save_antenna_model
   IF not antenna_flag THEN undefine_fhd,antenna
   timing=Systime(1)-t00

--- a/fhd_core/gridding/visibility_degrid.pro
+++ b/fhd_core/gridding/visibility_degrid.pro
@@ -15,6 +15,11 @@ FUNCTION visibility_degrid,image_uv,vis_weight_ptr,obs,psf,params,$
         IF conserve_memory GT 1E6 THEN mem_thresh=conserve_memory ELSE mem_thresh=1E8 ;in bytes
     ENDIF
 
+    IF keyword_set(beam_per_baseline) AND interp_flag THEN BEGIN
+        print, "WARNING: Cannot do beam per baseline and interpolation at the same time, turning off interpolation"
+        interp_flag = 0
+    ENDIF
+
     ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
     ; and the 2D derivatives for bilinear interpolation
     bin_n=baseline_grid_locations(obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,ri=ri,$

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -30,6 +30,7 @@ IF keyword_set(beam_per_baseline) AND interp_flag THEN BEGIN
     interp_flag = 0
 ENDIF
 
+
 ; For each unflagged baseline, get the minimum contributing pixel number for gridding 
 ; and the 2D derivatives for bilinear interpolation
 bin_n = baseline_grid_locations(obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,ri=ri,$
@@ -65,6 +66,7 @@ frequency_array=frequency_array[fi_use]
 complex_flag=psf.complex_flag
 psf_dim=psf.dim
 psf_resolution=psf.resolution
+group_arr=reform(psf.id[polarization,freq_bin_i[fi_use],bi_use])
 beam_arr=*psf.beam_ptr
 
 weights_flag=Keyword_Set(weights)
@@ -77,8 +79,6 @@ n_freq_use=N_Elements(frequency_array)
 psf_dim2=2*psf_dim
 psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
-; Restructure the psf ID such that the last dimension matches the visiblity array in order to use future index arrays
-group_arr=reform(rebin(reform(psf.id[polarization,freq_bin_i,*]),n_f_use,nbaselines,n_samples), n_f_use,n_samples*nbaselines)
 
 if keyword_set(beam_per_baseline) then begin
     ; Initialization for gridding operation via a low-res beam kernel, calculated per
@@ -185,7 +185,6 @@ IF map_flag THEN BEGIN
     FOR i=0,psf_dim-1 DO FOR j=0,psf_dim-1 DO $  
         *map_fn_inds[i,j]=psf2_inds[psf_dim-i:2*psf_dim-i-1,psf_dim-j:2*psf_dim-j-1]
 ENDIF
-
 
 FOR bi=0L,n_bin_use-1 DO BEGIN
     ; Cycle through sets of visibilities which contribute to the same data/model uv-plane pixels, and perform

--- a/fhd_core/gridding/visibility_grid.pro
+++ b/fhd_core/gridding/visibility_grid.pro
@@ -62,11 +62,9 @@ IF Ptr_valid(model_ptr) THEN BEGIN
 ENDIF
 frequency_array=(*obs.baseline_info).freq
 frequency_array=frequency_array[fi_use]
-
 complex_flag=psf.complex_flag
 psf_dim=psf.dim
 psf_resolution=psf.resolution
-group_arr=reform(psf.id[polarization,freq_bin_i[fi_use],bi_use])
 beam_arr=*psf.beam_ptr
 
 weights_flag=Keyword_Set(weights)
@@ -79,6 +77,8 @@ n_freq_use=N_Elements(frequency_array)
 psf_dim2=2*psf_dim
 psf_dim3=LONG64(psf_dim*psf_dim)
 bi_use_reduced=bi_use mod nbaselines
+; Restructure the psf ID such that the last dimension matches the visiblity array in order to use future index arrays
+group_arr=reform(rebin(reform(psf.id[polarization,freq_bin_i,*]),n_f_use,nbaselines,n_samples), n_f_use,n_samples*nbaselines)
 
 if keyword_set(beam_per_baseline) then begin
     ; Initialization for gridding operation via a low-res beam kernel, calculated per

--- a/fhd_core/setup_metadata/fhd_struct_init_meta.pro
+++ b/fhd_core/setup_metadata/fhd_struct_init_meta.pro
@@ -1,4 +1,4 @@
-FUNCTION fhd_struct_init_meta,file_path_vis,hdr,params,lon=lon,lat=lat,alt=alt,n_tile=n_tile,$
+FUNCTION fhd_struct_init_meta,file_path_vis,hdr,params,layout,lon=lon,lat=lat,alt=alt,n_tile=n_tile,$
     zenra_in=zenra_in,zendec_in=zendec_in,obsra_in=obsra_in,obsdec_in=obsdec_in,phasera_in=phasera_in,phasedec_in=phasedec_in,$
     rephase_to_zenith=rephase_to_zenith,precess=precess,degpix=degpix,dimension=dimension,elements=elements,$
     obsx=obsx,obsy=obsy,instrument=instrument,mirror_X=mirror_X,mirror_Y=mirror_Y,no_rephase=no_rephase,$
@@ -95,7 +95,7 @@ ENDIF ELSE BEGIN
     hist_A1=histogram(tile_A1,min=1,max=n_tile,/binsize,reverse_ind=ria)
     hist_B1=histogram(tile_B1,min=1,max=n_tile,/binsize,reverse_ind=rib)
     hist_AB=hist_A1+hist_B1
-    tile_names=indgen(n_tile)+1
+    tile_names=layout.antenna_numbers
     tile_use=where(hist_AB,n_tile_exist,complement=missing_i,ncomplement=missing_n)+1
     tile_height=Fltarr(n_tile)
     tile_flag0=intarr(n_tile)


### PR DESCRIPTION
A few little tweaks to the beam setup:

1) Better beam transfer handling. Actually attempts to match the group id* between the transferred beam and the observation via the unique baseline identifier. If it fails, then it sets the group id to the first one (standard style run)

*(aka the identifier which says which unique beam it is. If there is only one unique beam, then all baselines have the same group id)

2) Slight increase in the loop for gridding each baseline with Jack's uvw phasing in image space. Only helped by about 5%--10%, so not a huge improvement. 
 
3) Add dipole gain handling from the metafits. This is a simulation-based input. Could be expanded to make unique beams (future work).

4) The square beam volume for the gaussian decomposition of the beam. The square beam volume is part of the calculation for our observation volume, so extremely important. We calculate the analytic volume of a set of gaussians. This is actually an overestimate though due to the horizon edge and the beam-clip-and-renormalize option. While I've left the skeleton of the analytic volume in the code, I reverted the square beam volume calculation to the discrete estimate, which seems more accurate. 

