### PR TITLE
Preserve double precision in gridding

### DIFF
--- a/fhd_core/gridding/baseline_grid_locations.pro
+++ b/fhd_core/gridding/baseline_grid_locations.pro
@@ -99,8 +99,8 @@ Function baseline_grid_locations,obs,psf,params,n_bin_use=n_bin_use,bin_i=bin_i,
   ENDIF
 
   ; Center of baselines for x and y in units of pixels
-  xcen=Float(frequency_array#Temporary(kx_arr))
-  ycen=Float(frequency_array#Temporary(ky_arr))
+  xcen=frequency_array#Temporary(kx_arr)
+  ycen=frequency_array#Temporary(ky_arr)
 
   ; Pixel number offet per baseline for each uv-box subset 
   x_offset=Fix(Floor((xcen-Floor(xcen))*psf_resolution) mod psf_resolution, type=12) ; type=12 is unsigned int


### PR DESCRIPTION
I was trying to get pyFHD degridding to agree with FHD degridding and after a number of fixes they were agreeing to a part in 10^4, which didn't seem good enough. I ran the codes in parallel and compared various values until I found that the gridding kernels after interpolation were not agreeing to machine precision. Looking carefully at that code I found that the baseline centers (relative to the psf grid) were being explicitly cast to floats rather than being preserved as doubles. When I removed this cast, pyFHD's degridded visibilities agree with FHD to (double) machine precision.

I'm wondering why this cast is there, was there a concern about speed or memory use? I think we have repeatedly found that double precision is required, so I'd like to remove this casting unless there's a really compelling reason to leave them in.