### PR TITLE
Add support for uvfits files with uvws split between two variables

### DIFF
--- a/fhd_core/visibility_manipulation/vis_param_extract.pro
+++ b/fhd_core/visibility_manipulation/vis_param_extract.pro
@@ -1,9 +1,9 @@
 FUNCTION vis_param_extract,params,header, antenna_mod_index=antenna_mod_index
 
-
-uu_arr=Double(reform(params[header.uu_i,*]))
-vv_arr=Double(reform(params[header.vv_i,*]))
-ww_arr=Double(reform(params[header.ww_i,*]))
+; handle uu_i having 1 or 2 elements. If 2, they should be summed over
+uu_arr=total(Double(params[header.uu_i,*]), 1)
+vv_arr=total(Double(params[header.vv_i,*]), 1)
+ww_arr=total(Double(params[header.ww_i,*]), 1)
 
 ; Use both date fields if available in the uvfits file
 ; This doesn't give julian dates; those are calcuated in fhd_struct_init_meta


### PR DESCRIPTION
This is enables double precision uvws. The convention of writing out a double precision number as two fields to be summed is a standard FITS approach and is what is almost always done for time. pyuvdata now allows for this for uvws, so FHD should handle them properly.