### PR TITLE
HEALPix cubes can now be saved out in double precision

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -96,7 +96,7 @@ This is a work in progress; please add keywords as you find them in alphabetical
 
 **bandpass_calibrate**: calculates a bandpass. This is an average of tiles by frequency by polarization (default), beamformer-to-LNA cable types by frequency by polarization (see `cable_bandpass_fit`), or over the whole season by pointing by by cable type by frequency by polarization via a read-in file (see `saved_run_bp`). If unset, no by-frequency bandpass is used. <br />
   -*Turn off/on*: 0/1 <br />
-  -*Default*: 1 <br />  
+  -*Default*: 1 <br />
   -*eor_wrapper_defaults*: 1 <br />
 
 **cable_bandpass_fit**: average the calibration solutions across tiles within a cable grouping for the particular instrument. <br />
@@ -493,14 +493,14 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Dependency*: `export_images` must be set to 1 in order for the keyword to take effect.  <br />
   -*Turn off/on*: 0/1 <br />
   -*Default*: 0 <br />
-  
+
 **no_png**: do not export any pngs (including standard images and images of calibration solutions). <br />
   -*Dependency*: `export_images` must be set to 1 in order for the keyword to take effect. <br />
   -*Turn off/on*: 0/1 <br />
   -*Default*: 0 <br />
 
-**output_directory**: the absolute path to the output directory for the FHD output run folder. See `version`.     
-  -*Default*: not set <br />    
+**output_directory**: the absolute path to the output directory for the FHD output run folder. See `version`.
+  -*Default*: not set <br />
 
 **pad_uv_image**: pad the UV image by this factor with 0's along the outside so that output images are at a higher resolution. <br />
   -*Default*: 1. <br />
@@ -559,26 +559,26 @@ WARNING! Options in this section may change without notice, and should never be 
  -*Default*: 4 for instrument="mwa32t", depends on the number of frequency channels for instrument="mwa" <br />
 
 **dead_dipole_list**: an array of 3 x # of dead dipoles, where column 0 is the tile name, column 1 is the polarization (0:x, 1:y), and column 2 is the dipole number. These dipoles are flagged, which greatly increases memory usage due to the creation of many separate tile beams. <br />
-  -*Default*: not set <br />  
+  -*Default*: not set <br />
 
 **flag_calibration**: flags antennas based on calculations in `vis_calibration_flag.pro`.<br />
   -*Needs update*: keyword check both in general_obs and vis_calibrate !Q <br />
   -*Turn off/on*: 0/1 <br />
-  -*Default*: 1 <br />  
+  -*Default*: 1 <br />
 
 **flag_dead_dipoles**: flag the dead dipoles listed in `<instrument>_dead_dipole_list.txt` for the golden set of Aug 23, 2013. This greatly increases memory usage due to the creation of many separate tile beams. <br />
-  -*Default*: not set <br />  
+  -*Default*: not set <br />
 
 **flag_visibilities**: flag visibilities based on calculations in `vis_flag.pro`. <br />
   -*Turn off/on*: 0/1 <br />
-  -*Default*: 0 <br />  
+  -*Default*: 0 <br />
   -*eor_wrapper_defaults*: 0 <br />
 
 **freq_end**: Frequency in MHz to end the observation. Flags frequencies greater than it.  <br />
   -*Default*: not set<br />
 
 **freq_start**: Frequency in MHz to begin the observation. Flags frequencies less than it.  <br />
-  -*Default*: not set<br />  
+  -*Default*: not set<br />
 
 **no_calibration_frequency_flagging**: do not flag frequencies based off of zeroed calibration gains. <br />
   -*Needs updating*: might be better if changed to calibration_frequency_flagging and change the logic (avoid the double negative) !Q. <br />
@@ -624,8 +624,8 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Default*: 0 <br />
   -*eor_wrapper_defaults*: 1 <br />
 
-**obs_id**: the unique identifier for the observation. Examples are GPS seconds or Julian Dates. The input uvfits file must share this unique identifier name: `<obs_id>.uvfits`.    
-  -*Default*: not set    
+**obs_id**: the unique identifier for the observation. Examples are GPS seconds or Julian Dates. The input uvfits file must share this unique identifier name: `<obs_id>.uvfits`.
+  -*Default*: not set
 
 **override_target_phasedec**: dec of the target phase center, which overrides the value supplied in the metafits under the header keyword DECPHASE. If the metafits doesn't exist, it ovverides the value supplied in the uvfits under the header keyword Dec.<br />
   -*Default*: not set<br />
@@ -684,6 +684,9 @@ WARNING! Options in this section may change without notice, and should never be 
 
 ## Resolution
 
+**double_precision**: Set equal to 1 to enable double precision in all calculations. <br />
+  -*Default*: 0 <br />
+
 **baseline_threshold**: Positive numbers cut baselines shorter than the given number in wavelengths. Negative numbers cut baselines longer than the given number in wavelengths. This keyword is deprecated because it does not return the correct image normalization. Consider using min_baseline and max_baseline instead. <br />
   -*Default*: 0 <br />
 
@@ -715,19 +718,19 @@ WARNING! Options in this section may change without notice, and should never be 
   -*Default*: 2 <br />
 
 **ps_beam_threshold** : Minimum value to which to calculate the beam out to in image space. The beam in UV space is pre-calculated and may have its own `beam_threshold` (see that keyword for more information), and this is only an additional cut in image space. <br />
-  -*Default*: not set<br />     
+  -*Default*: not set<br />
 
 **ps_degpix** : Degrees per pixel for Healpix cube generation. If `ps_kspan`, `ps_dimension`, or `ps_degpix` are not set, the UV plane dimension is calculated from the FoV and the `degpix` from the obs structure.<br />
   -*Dependency*: `ps_kspan` and `ps_dimension` must not be set in order for the keyword to take effect. <br />
-  -*Default*: not set<br />  
+  -*Default*: not set<br />
 
 **ps_dimension** : UV plane dimension in pixel number for Healpix cube generation. Overrides `ps_degpix` if set. If `ps_kspan`, `ps_dimension`, or `ps_degpix` are not set, the UV plane dimension is calculated from the FoV and the `degpix` from the obs structure.<br />
   -*Dependency*: `ps_kspan` must not be set in order for the keyword to take effect. <br />
-  -*Default*: not set<br />    
+  -*Default*: not set<br />
 
 **ps_fov** : Field of view in degrees for Healpix cube generation. Overrides `kpix` in the obs structure if set.<br />
   -*Dependency*: `ps_kbinsize` must not be set in order for the keyword to take effect. <br />
-  -*Default*: not set<br />  
+  -*Default*: not set<br />
 
 **ps_kbinsize** : UV pixel size in wavelengths to grid for Healpix cube generation. Overrides `ps_fov` and the `kpix` in the obs structure if set. <br />
   -*Default*: not set<br />

--- a/fhd_core/HEALPix/combine_obs_healpix.pro
+++ b/fhd_core/HEALPix/combine_obs_healpix.pro
@@ -76,6 +76,7 @@ ENDFOR
 n_pol=Min(obs_arr.n_pol)
 IF Keyword_Set(nside) THEN nside_use=nside ELSE nside=nside_use
 IF ~Keyword_Set(silent) THEN print,'Creating HEALPix maps using nside='+Strn(nside)
+double_precision=Max(obs_arr.double_precision)
 
 stokes_model_hpx=Ptrarr(n_pol)
 stokes_dirty_hpx=Ptrarr(n_pol)
@@ -260,10 +261,10 @@ FOR obs_i=0L,n_obs-1 DO BEGIN
             weights_hpx0[ind_map0]=(*weights_hpx[pol_i])
             *weights_hpx[pol_i]=(weights_hpx0)
         ENDIF 
-        (*weights_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(stokes_weights,hpx_cnv)*n_vis_rel
-        (*stokes_dirty_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_dirty[pol_i],hpx_cnv)*n_vis_rel
-        IF model_flag THEN (*stokes_model_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_model[pol_i],hpx_cnv)*n_vis_rel
-        IF source_flag THEN (*stokes_sources_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_sources[pol_i],hpx_cnv)*n_vis_rel
+        (*weights_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(stokes_weights,hpx_cnv,double_precision=double_precision)*n_vis_rel
+        (*stokes_dirty_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_dirty[pol_i],hpx_cnv,double_precision=double_precision)*n_vis_rel
+        IF model_flag THEN (*stokes_model_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_model[pol_i],hpx_cnv,double_precision=double_precision)*n_vis_rel
+        IF source_flag THEN (*stokes_sources_hpx[pol_i])[ind_map1]+=healpix_cnv_apply(*stokes_sources[pol_i],hpx_cnv,double_precision=double_precision)*n_vis_rel
     ENDFOR
     IF N_Elements(n_obs_hpx) EQ 0 THEN n_obs_hpx=intarr(n_hpx)
     IF reform_flag THEN BEGIN

--- a/fhd_core/HEALPix/healpix_cnv_apply.pro
+++ b/fhd_core/HEALPix/healpix_cnv_apply.pro
@@ -1,13 +1,15 @@
-FUNCTION healpix_cnv_apply,image,hpx_cnv,timing=timing
+FUNCTION healpix_cnv_apply,image,hpx_cnv,timing=timing,double_precision=double_precision
 t0=Systime(1)
+IF N_Elements(double_precision) EQ 0 THEN double_precision=0
 
 dimension=(size(image,/dimension))[0]
 elements=(size(image,/dimension))[1]
 
 image_vector=reform(image,Float(dimension)*elements)
-IF size(hpx_cnv,/type) EQ 10 THEN hpx_map=Fltarr(N_Elements((*hpx_cnv).inds)) $
-    ELSE hpx_map=Fltarr(N_Elements(hpx_cnv.inds))
-SPRSAX2,hpx_cnv,image_vector,hpx_map,transpose=1,mask=0
+IF size(hpx_cnv,/type) EQ 10 THEN hpx_map_size=N_Elements((*hpx_cnv).inds) $
+    ELSE hpx_map_size=N_Elements(hpx_cnv.inds)
+IF Keyword_Set(double_precision) THEN hpx_map=Dblarr(hpx_map_size) ELSE hpx_map=Fltarr(hpx_map_size)
+SPRSAX2,hpx_cnv,image_vector,hpx_map,transpose=1,mask=0,double=double_precision
 
 timing=Systime(1)-t0
 RETURN,hpx_map

--- a/fhd_core/HEALPix/healpix_snapshot_cube_generate.pro
+++ b/fhd_core/HEALPix/healpix_snapshot_cube_generate.pro
@@ -54,6 +54,7 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
   
   obs_out=fhd_struct_update_obs(obs_in,n_pol=n_pol,beam_nfreq_avg=ps_nfreq_avg,FoV=FoV_use,dimension=dimension_use)
   ps_psf_resolution=Round(psf_in.resolution*obs_out.kpix/obs_in.kpix)
+  double_precision=obs_out.double_precision
   IF (kbinsize EQ obs_in.kpix) AND Min((*obs_out.baseline_info).fbin_i EQ (*obs_in.baseline_info).fbin_i) THEN BEGIN
     ;If the beam model to be used for making the snapshot cubes is the same as the one used for imaging, then simply copy the existing data and don't recalculate it
     IF N_Elements(antenna) EQ 0 THEN fhd_save_io,status_str,antenna_out,var='antenna',/restore,file_path_fhd=file_path_fhd,_Extra=extra ELSE antenna_out=antenna
@@ -162,18 +163,18 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
 
         FOR freq_i=Long64(0),n_freq_use-1 DO BEGIN
 
-            beam_squared_cube[n_hpx*freq_i]=healpix_cnv_apply((*beam_arr[pol_i,freq_i])*nf_vis_use[freq_i],hpx_cnv)
-            weights_cube[n_hpx*freq_i]=healpix_cnv_apply((*weights_arr1[pol_i,freq_i]),hpx_cnv)
-            variance_cube[n_hpx*freq_i]=healpix_cnv_apply((*variance_arr1[pol_i,freq_i]),hpx_cnv)
+            beam_squared_cube[n_hpx*freq_i]=healpix_cnv_apply((*beam_arr[pol_i,freq_i])*nf_vis_use[freq_i],hpx_cnv,double_precision=double_precision)
+            weights_cube[n_hpx*freq_i]=healpix_cnv_apply((*weights_arr1[pol_i,freq_i]),hpx_cnv,double_precision=double_precision)
+            variance_cube[n_hpx*freq_i]=healpix_cnv_apply((*variance_arr1[pol_i,freq_i]),hpx_cnv,double_precision=double_precision)
 
             IF residual_flag THEN BEGIN
-                res_cube[n_hpx*freq_i]=healpix_cnv_apply((*residual_arr1[pol_i,freq_i]),hpx_cnv)
+                res_cube[n_hpx*freq_i]=healpix_cnv_apply((*residual_arr1[pol_i,freq_i]),hpx_cnv,double_precision=double_precision)
             ENDIF
             IF dirty_flag THEN BEGIN
-                dirty_cube[n_hpx*freq_i]=healpix_cnv_apply((*dirty_arr1[pol_i,freq_i]),hpx_cnv)
+                dirty_cube[n_hpx*freq_i]=healpix_cnv_apply((*dirty_arr1[pol_i,freq_i]),hpx_cnv,double_precision=double_precision)
             ENDIF
             IF model_flag THEN BEGIN
-                model_cube[n_hpx*freq_i]=healpix_cnv_apply((*model_arr1[pol_i,freq_i]),hpx_cnv)
+                model_cube[n_hpx*freq_i]=healpix_cnv_apply((*model_arr1[pol_i,freq_i]),hpx_cnv,double_precision=double_precision)
             ENDIF
 
         ENDFOR

--- a/fhd_core/HEALPix/healpix_snapshot_cube_generate.pro
+++ b/fhd_core/HEALPix/healpix_snapshot_cube_generate.pro
@@ -4,20 +4,20 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     rephase_weights=rephase_weights,n_avg=n_avg,vis_weights=vis_weights,split_ps_export=split_ps_export,$
     restrict_hpx_inds=restrict_hpx_inds,hpx_radius=hpx_radius,cmd_args=cmd_args,save_uvf=save_uvf,save_imagecube=save_imagecube,$
     obs_out=obs_out,psf_out=psf_out,ps_tile_flag_list=ps_tile_flag_list,_Extra=extra
-    
+
   t0=Systime(1)
-  
+
   IF N_Elements(silent) EQ 0 THEN silent=0
   IF N_Elements(status_str) EQ 0 THEN fhd_save_io,status_str,file_path_fhd=file_path_fhd,/no_save
   IF N_Elements(rephase_weights) EQ 0 THEN rephase_weights=1
-  
+
   IF Keyword_Set(split_ps_export) THEN cube_name=['hpx_even','hpx_odd'] $
     ELSE cube_name='healpix_cube'
-  
+
   IF N_Elements(obs_in) EQ 0 THEN fhd_save_io,status_str,obs_in,var='obs',/restore,file_path_fhd=file_path_fhd,_Extra=extra
   n_pol=obs_in.n_pol
   n_freq=obs_in.n_freq
-  
+
   ;whether cubes are recalculated is now set in fhd_setup (or array_simulator) through status_str
   IF Keyword_Set(split_ps_export) THEN cube_test=Min(status_str.hpx_even[0:n_pol-1])<Min(status_str.hpx_odd[0:n_pol-1]) $
     ELSE cube_test=Min(status_str.healpix_cube[0:n_pol-1])
@@ -25,33 +25,33 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     print,'HEALPix cubes not recalculated'
     RETURN
   ENDIF
-  
+
   IF N_Elements(psf_in) EQ 0 THEN fhd_save_io,status_str,psf_in,var='psf',/restore,file_path_fhd=file_path_fhd,_Extra=extra
   IF N_Elements(params) EQ 0 THEN fhd_save_io,status_str,params,var='params',/restore,file_path_fhd=file_path_fhd,_Extra=extra
   IF N_Elements(cal) EQ 0 THEN IF status_str.cal GT 0 THEN fhd_save_io,status_str,cal,var='cal',/restore,file_path_fhd=file_path_fhd,_Extra=extra
-  
+
   IF ~Keyword_Set(n_avg) THEN n_avg=1 ;default of no averaging
   n_freq_use=Floor(n_freq/n_avg)
   IF N_Elements(ps_beam_threshold) GT 0 THEN beam_threshold=ps_beam_threshold ELSE beam_threshold=0
-  
+
   IF Keyword_Set(ps_kbinsize) THEN kbinsize=ps_kbinsize ELSE $
     IF Keyword_Set(ps_fov) THEN kbinsize=!RaDeg/ps_FoV ELSE kbinsize=obs_in.kpix
   FoV_use=!RaDeg/kbinsize
-  
+
   IF Keyword_Set(ps_kspan) THEN dimension_use=ps_kspan/kbinsize ELSE $
     IF Keyword_Set(ps_dimension) THEN dimension_use=ps_dimension ELSE $
     IF Keyword_Set(ps_degpix) THEN dimension_use=FoV_use/ps_degpix ELSE dimension_use=FoV_use/obs_in.degpix
-  
+
   nfreq_avg_in=Round(n_freq/Max(psf_in.fbin_i+1))
   IF ~Keyword_Set(ps_nfreq_avg) THEN  ps_nfreq_avg=nfreq_avg_in
-  
+
   degpix_use=FoV_use/dimension_use
   pix_sky=4.*!Pi*!RaDeg^2./degpix_use^2.
   Nside_chk=2.^(Ceil(ALOG(Sqrt(pix_sky/12.))/ALOG(2))) ;=1024. for 0.1119 degrees/pixel
   IF ~Keyword_Set(nside) THEN nside_use=Nside_chk
   nside_use=nside_use>Nside_chk
   IF Keyword_Set(nside) THEN nside_use=nside ELSE nside=nside_use
-  
+
   obs_out=fhd_struct_update_obs(obs_in,n_pol=n_pol,beam_nfreq_avg=ps_nfreq_avg,FoV=FoV_use,dimension=dimension_use)
   ps_psf_resolution=Round(psf_in.resolution*obs_out.kpix/obs_in.kpix)
   double_precision=obs_out.double_precision
@@ -60,7 +60,7 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     IF N_Elements(antenna) EQ 0 THEN fhd_save_io,status_str,antenna_out,var='antenna',/restore,file_path_fhd=file_path_fhd,_Extra=extra ELSE antenna_out=antenna
     psf_out=psf_in
   ENDIF ELSE  psf_out=beam_setup(obs_out,0,antenna_out,/no_save,psf_resolution=ps_psf_resolution,/silent,_Extra=extra)
-  
+
   beam_arr=beam_image_cube(obs_out,psf_out,n_freq=n_freq_use,beam_mask=beam_mask,/square,beam_threshold=beam_threshold)
   if N_Elements(hpx_radius) EQ 0 then hpx_radius=FoV_use/sqrt(2.)
   hpx_cnv=healpix_cnv_generate(obs_out,file_path_fhd=file_path_fhd,nside=nside_use,restore_last=0,/no_save,$
@@ -68,13 +68,13 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
   IF Keyword_Set(restrict_hpx_inds) THEN nside=nside_use
   hpx_inds=hpx_cnv.inds
   n_hpx=N_Elements(hpx_inds)
-  
+
   fhd_log_settings,file_path_fhd+'_ps',obs=obs_out,psf=psf_out,antenna=antenna_out,cal=cal,cmd_args=cmd_args,/overwrite,sub_dir='metadata'
   undefine_fhd,antenna_out
-  
+
   IF Min(Ptr_valid(vis_weights)) LT n_pol THEN fhd_save_io,status_str,vis_weights_use,var='vis_weights',/restore,file_path_fhd=file_path_fhd,_Extra=extra $
     ELSE vis_weights_use=Pointer_copy(vis_weights)
-  
+
   IF Keyword_Set(ps_tile_flag_list) THEN BEGIN
     vis_flag_tiles, obs_out, vis_weights_use, tile_flag_list=ps_tile_flag_list
   ENDIF
@@ -93,7 +93,7 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     ENDFOR
     IF ~Keyword_Set(silent) THEN print,"...Done"
   ENDIF
-  
+
   IF Keyword_Set(split_ps_export) THEN BEGIN
     n_iter=2
     vis_weights_use=split_vis_weights(obs_out,vis_weights_use,bi_use=bi_use,_Extra=extra)
@@ -108,10 +108,10 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     uvf_name = ''
     if keyword_set(save_imagecube) then imagecube_filepath = file_path_fhd+'_gridded_imagecube.sav'
   ENDELSE
-  
+
   residual_flag=obs_out.residual
   model_flag=0
-  
+
   IF Min(Ptr_valid(vis_model_arr)) THEN IF N_Elements(*vis_model_arr[0]) GT 0 THEN model_flag=1
   IF residual_flag EQ 0 THEN IF model_flag EQ 0 THEN BEGIN
     vis_model_arr=Ptrarr(n_pol)
@@ -121,12 +121,12 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
         FOR pol_i=0,n_pol-1 DO BEGIN
             fhd_save_io,status_str,vis_model_ptr,var='vis_model_ptr',/restore,file_path_fhd=file_path_fhd,obs=obs_out,pol_i=pol_i,_Extra=extra
             vis_model_arr[pol_i]=vis_model_ptr
-        ENDFOR 
+        ENDFOR
         IF ~Keyword_Set(silent) THEN print,"...Done"
     ENDIF
   ENDIF
   IF model_flag AND ~residual_flag THEN dirty_flag=1 ELSE dirty_flag=0
-  
+
   t_hpx=0.
   t_split=0.
   obs_out_ref=obs_out
@@ -135,7 +135,7 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     obs=obs_out_ref ;will have some values over-written!
     obs_in=obs_in_ref
     psf=psf_out
-    
+
     residual_arr1=vis_model_freq_split(obs_in,status_str,psf_in,params,vis_weights_use,obs_out=obs,psf_out=psf,rephase_weights=rephase_weights,$
       weights_arr=weights_arr1,variance_arr=variance_arr1,model_arr=model_arr1,n_avg=n_avg,timing=t_split1,/fft,$
       file_path_fhd=file_path_fhd,vis_n_arr=vis_n_arr,/preserve_visibilities,vis_data_arr=vis_arr,vis_model_arr=vis_model_arr,$
@@ -149,15 +149,17 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
     nf_vis=obs.nf_vis
     nf_vis_use=Lonarr(n_freq_use)
     FOR freq_i=0L,n_freq_use-1 DO nf_vis_use[freq_i]=Total(nf_vis[freq_i*n_avg:(freq_i+1)*n_avg-1])
-    
+
     t_hpx0=Systime(1)
-    
-    beam_squared_cube=fltarr(n_hpx,n_freq_use)
-    weights_cube=fltarr(n_hpx,n_freq_use)
-    variance_cube=fltarr(n_hpx,n_freq_use)
-    IF residual_flag THEN res_cube=fltarr(n_hpx,n_freq_use)
-    IF dirty_flag THEN dirty_cube=fltarr(n_hpx,n_freq_use)
-    IF model_flag THEN model_cube=fltarr(n_hpx,n_freq_use)
+
+    arr_fn = (double_precision) ? 'dblarr' : 'fltarr'
+
+    beam_squared_cube = call_function(arr_fn, n_hpx, n_freq_use)
+    weights_cube      = call_function(arr_fn, n_hpx, n_freq_use)
+    variance_cube     = call_function(arr_fn, n_hpx, n_freq_use)
+    IF residual_flag THEN res_cube = call_function(arr_fn, n_hpx, n_freq_use)
+    IF dirty_flag    THEN dirty_cube = call_function(arr_fn, n_hpx, n_freq_use)
+    IF model_flag    THEN model_cube = call_function(arr_fn, n_hpx, n_freq_use)
 
     FOR pol_i=0,n_pol-1 DO BEGIN
 
@@ -188,15 +190,15 @@ PRO healpix_snapshot_cube_generate,obs_in,status_str,psf_in,cal,params,vis_arr,v
         fhd_save_io,status_str,file_path_fhd=file_path_fhd,var=cube_name[iter],pol_i=pol_i,/force,_Extra=extra
 
     ENDFOR
-    
+
     IF Keyword_Set(save_imagecube) THEN BEGIN
         save, filename = imagecube_filepath[iter], dirty_arr1, residual_arr1, model_arr1, weights_arr1, variance_arr1, beam_arr, nf_vis_use, obs_out, /compress
     ENDIF
-    
+
     undefine_fhd,weights_arr1,variance_arr1,residual_arr1,dirty_arr1,model_arr1 ;free memory for beam_arr later!
     dirty_cube=(model_cube=(res_cube=(weights_cube=(variance_cube=(beam_squared_cube=0)))))
     IF iter EQ n_iter-1 THEN undefine_fhd,beam_arr
-    
+
 ENDFOR
 obs_out=obs ;for return
 Ptr_free,vis_weights_use

--- a/fhd_core/HEALPix/obs_weight_healpix.pro
+++ b/fhd_core/HEALPix/obs_weight_healpix.pro
@@ -5,6 +5,7 @@ n_obs=N_Elements(obs_arr)
 n_pol=obs_arr[0].n_pol
 n_hpx=N_Elements(hpx_inds)
 beam_square=Ptrarr(n_pol)
+double_precision=Max(obs_arr.double_precision)
 
 IF Arg_present(obs_weight_arr) THEN BEGIN
     weight_return_flag=1
@@ -21,7 +22,7 @@ FOR obs_i=0L,n_obs-1 DO BEGIN
     obs_weight_single/=(2.<n_pol)
 ;    IF mask_flag THEN obs_weight_single*=*beam_mask_arr[obs_i]
     
-    weight_hpx[*hpx_ind_map[obs_i]]+=healpix_cnv_apply(obs_weight_single,hpx_cnv_arr[obs_i])
+    weight_hpx[*hpx_ind_map[obs_i]]+=healpix_cnv_apply(obs_weight_single,hpx_cnv_arr[obs_i],double_precision=double_precision)
     IF Keyword_Set(weight_return_flag) THEN obs_weight_arr[obs_i]=Ptr_new(Temporary(obs_weight_single))
 ENDFOR
 

--- a/fhd_core/deconvolution/fhd_multi.pro
+++ b/fhd_core/deconvolution/fhd_multi.pro
@@ -40,6 +40,7 @@ reject_pol_sources=fhd_params.reject_pol_sources
 beam_width=beam_width_calculate(obs_arr,min_restored_beam_width=1.,/FWHM)
 local_max_radius=beam_width*2.
 local_radius=local_max_radius*Mean(obs_arr.degpix)
+double_precision=Max(obs_arr.double_precision)
 source_alias_radius=Mean(obs_arr.degpix*obs_arr.dimension)/4.
 calibration_model_subtract=fhd_params.cal_subtract
 filter_background=fhd_params.filter_background
@@ -271,7 +272,7 @@ FOR i=0L,max_iter-1 DO BEGIN
         
         res_stokes=stokes_cnv(res_arr,jones_arr[obs_i],obs_arr[obs_i],beam=beam_model[*,obs_i],/square,_Extra=extra)
         *res_stokes_arr[obs_i]=*res_stokes[0]
-        FOR pol_i=0,n_pol-1 DO (*residual_stokes_hpx[pol_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply(*res_stokes[pol_i]*(*obs_weight[obs_i]),hpx_cnv[obs_i])
+        FOR pol_i=0,n_pol-1 DO (*residual_stokes_hpx[pol_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply(*res_stokes[pol_i]*(*obs_weight[obs_i]),hpx_cnv[obs_i],double_precision=double_precision)
         ptr_free,res_stokes
     ENDFOR
     

--- a/fhd_core/gridding/vis_split_export_multi.pro
+++ b/fhd_core/gridding/vis_split_export_multi.pro
@@ -43,6 +43,7 @@ Nside_chk=2.^(Ceil(ALOG(Sqrt(pix_sky/12.))/ALOG(2))) ;=1024. for 0.1119 degrees/
 IF ~Keyword_Set(nside) THEN nside_use=Nside_chk
 nside_use=nside_use>Nside_chk
 IF Keyword_Set(nside) THEN nside_use=nside ELSE nside=nside_use
+double_precision=Max(obs_arr.double_precision)
 
 residual_flag=Round(Mean(obs_arr.residual)) ;use Mean() not Median() because Median() will give an error if there is only one element
 model_flag=intarr(n_obs)+1
@@ -132,13 +133,13 @@ FOR obs_i=0,n_obs-1 DO BEGIN
     FOR pol_i=0,n_pol-1 DO FOR freq_i=0,n_freq_use-1 DO BEGIN
         IF dirty_flag THEN IF stddev(*dirty_arr1[pol_i,freq_i]) EQ 0 THEN CONTINUE 
         IF ~dirty_flag THEN IF stddev(*residual_arr1[pol_i,freq_i]) EQ 0 THEN CONTINUE
-        (*weights_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*weights_arr1[pol_i,freq_i]),hpx_cnv[obs_i])
-        (*variance_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*variance_arr1[pol_i,freq_i]),hpx_cnv[obs_i])
+        (*weights_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*weights_arr1[pol_i,freq_i]),hpx_cnv[obs_i],double_precision=double_precision)
+        (*variance_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*variance_arr1[pol_i,freq_i]),hpx_cnv[obs_i],double_precision=double_precision)
         IF dirty_flag THEN *residual_arr1[pol_i,freq_i]=*dirty_arr1[pol_i,freq_i]-*model_arr1[pol_i,freq_i]
-        (*residual_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*residual_arr1[pol_i,freq_i]),hpx_cnv[obs_i])
-        IF dirty_flag THEN (*dirty_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*dirty_arr1[pol_i,freq_i]),hpx_cnv[obs_i])
-        IF model_flag THEN (*model_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*model_arr1[pol_i,freq_i]),hpx_cnv[obs_i])
-        (*beam_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*beam[pol_i,freq_i])^2.,hpx_cnv)
+        (*residual_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*residual_arr1[pol_i,freq_i]),hpx_cnv[obs_i],double_precision=double_precision)
+        IF dirty_flag THEN (*dirty_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*dirty_arr1[pol_i,freq_i]),hpx_cnv[obs_i],double_precision=double_precision)
+        IF model_flag THEN (*model_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*model_arr1[pol_i,freq_i]),hpx_cnv[obs_i],double_precision=double_precision)
+        (*beam_hpx_arr[pol_i,freq_i])[*hpx_ind_map[obs_i]]+=healpix_cnv_apply((*beam[pol_i,freq_i])^2.,hpx_cnv,double_precision=double_precision)
     ENDFOR
     t_hpx1=Systime(1)
     t_hpx+=t_hpx1-t_hpx0


### PR DESCRIPTION
This is an extension to PR #346, fixing a small bug in `healpix_snapshot_cube_generate.pro` where cubes were initialized using `fltarr`, disregarding the `double_precision` keyword. Cubes are now initialized as either `fltarr` or `dblarr` depending on the value of `double_precision`, enabling them to be saved out in double precision.